### PR TITLE
Prevent implicit resolution for Default type class

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import caseapp._
 ```scala
 case class Options(
   user: Option[String],
-  enableFoo: Boolean,
+  enableFoo: Boolean = false,
   file: List[String]
 )
 
@@ -32,33 +32,25 @@ CaseApp.parse[Options](
 
 
 
-### Default values
+### Required and optional arguments
 
-Most primitive types have default values, like `0` for `Int`, or `false`
-for `Double`. Options default to `None`, and sequences to `Nil`.
-Full list in the [source](https://github.com/alexarchambault/case-app/blob/master/src/main/scala/caseapp/core/Default.scala).
+All arguments are required by default. To define an optional argument simply
+wrap its type into `Option[T]`.
+
+Optional arguments can also be defined by providing a default value.
+There are two ways to do that:
+- providing default value ad hoc in the case class definition
+- defining default value for a type with [Default](https://github.com/alexarchambault/case-app/blob/master/src/main/scala/caseapp/core/Default.scala) 
+type class
 
 ```scala
 case class Options(
   user: Option[String],
-  enableFoo: Boolean,
-  file: List[String]
+  enableFoo: Boolean = false,
+  file: List[String] = Nil
 )
 
 CaseApp.parse[Options](Seq()) == Right((Options(None, false, Nil), Seq.empty))
-```
-
-
-
-
-Alternatively, default values can be manually specified, like
-```scala
-case class Options(
-  user: String = "default",
-  enableFoo: Boolean = true
-)
-
-CaseApp.parse[Options](Seq()) == Right((Options("default", true), Seq.empty))
 ```
 
 
@@ -72,7 +64,7 @@ should be typed as lists, e.g. `file` in
 ```scala
 case class Options(
   user: Option[String],
-  enableFoo: Boolean,
+  enableFoo: Boolean = false,
   file: List[String]
 )
 

--- a/core/shared/src/main/scala/caseapp/core/Default.scala
+++ b/core/shared/src/main/scala/caseapp/core/Default.scala
@@ -25,6 +25,8 @@ object Default extends PlatformDefaults {
      defaultOr: Strict[DefaultOr[L, D]]
    ): Default[CC] =
     Default.instance(gen.from(defaultOr.value(default.value())))
+
+  implicit def option[T]: Default[Option[T]] = Default.instance[Option[T]](None)
 }
 
 trait DefaultOr[L <: HList, D <: HList] {
@@ -74,6 +76,5 @@ object Defaults {
   implicit val counter: Default[Int @@ Counter] = Default.instance(Tag of 0)
   implicit val string: Default[String] = Default.instance("", str => s""""$str"""")
 
-  implicit def option[T]: Default[Option[T]] = Default.instance[Option[T]](None)
   implicit def list[T]: Default[List[T]] = Default.instance[List[T]](Nil)
 }

--- a/core/shared/src/main/scala/caseapp/core/Default.scala
+++ b/core/shared/src/main/scala/caseapp/core/Default.scala
@@ -25,20 +25,6 @@ object Default extends PlatformDefaults {
      defaultOr: Strict[DefaultOr[L, D]]
    ): Default[CC] =
     Default.instance(gen.from(defaultOr.value(default.value())))
-
-  implicit val unit: Default[Unit] = Default.instance(())
-  implicit val int: Default[Int] = Default.instance(0)
-  implicit val long: Default[Long] = Default.instance(0L)
-  implicit val float: Default[Float] = Default.instance(0f)
-  implicit val double: Default[Double] = Default.instance(0d)
-  implicit val bigDecimal: Default[BigDecimal] = Default.instance(BigDecimal(0))
-  implicit val boolean: Default[Boolean] = Default.instance(false)
-  implicit val counter: Default[Int @@ Counter] = Default.instance(Tag of 0)
-  implicit val string: Default[String] = Default.instance("", str => s""""$str"""")
-
-  implicit def option[T]: Default[Option[T]] = Default.instance[Option[T]](None)
-  implicit def list[T]: Default[List[T]] = Default.instance[List[T]](Nil)
-
 }
 
 trait DefaultOr[L <: HList, D <: HList] {
@@ -75,4 +61,19 @@ object DefaultOr extends LowPriorityDefaultOr {
     instance { case Some(d) :: td =>
       d :: tail(td)
     }
+}
+
+object Defaults {
+  implicit val unit: Default[Unit] = Default.instance(())
+  implicit val int: Default[Int] = Default.instance(0)
+  implicit val long: Default[Long] = Default.instance(0L)
+  implicit val float: Default[Float] = Default.instance(0f)
+  implicit val double: Default[Double] = Default.instance(0d)
+  implicit val bigDecimal: Default[BigDecimal] = Default.instance(BigDecimal(0))
+  implicit val boolean: Default[Boolean] = Default.instance(false)
+  implicit val counter: Default[Int @@ Counter] = Default.instance(Tag of 0)
+  implicit val string: Default[String] = Default.instance("", str => s""""$str"""")
+
+  implicit def option[T]: Default[Option[T]] = Default.instance[Option[T]](None)
+  implicit def list[T]: Default[List[T]] = Default.instance[List[T]](Nil)
 }

--- a/core/shared/src/test/scala/caseapp/Tests.scala
+++ b/core/shared/src/test/scala/caseapp/Tests.scala
@@ -5,6 +5,7 @@ import org.scalatest._
 
 class Tests extends FlatSpec with Matchers {
   import Definitions._
+  import core.Defaults._
 
   "A parser" should "parse no args" in {
     Parser[NoArgs].apply(Seq.empty) shouldEqual Right((NoArgs(), Seq.empty))

--- a/doc/README.md
+++ b/doc/README.md
@@ -45,7 +45,7 @@ wrap its type into `Option[T]`.
 Optional arguments can also be defined by providing a default value.
 There are two ways to do that:
 - providing default value ad hoc in the case class definition
-- defining default value for a type with [Default](https://github.com/alexarchambault/case-app/blob/master/src/main/scala/caseapp/core/Default.scala) 
+- defining default value for a type with [Default](https://github.com/alexarchambault/case-app/blob/master/core/shared/src/main/scala/caseapp/core/Default.scala) 
 type class
 
 ```tut:silent

--- a/doc/README.md
+++ b/doc/README.md
@@ -20,7 +20,7 @@ import caseapp._
 ```tut:silent
 case class Options(
   user: Option[String],
-  enableFoo: Boolean,
+  enableFoo: Boolean = false,
   file: List[String]
 )
 
@@ -37,17 +37,22 @@ assert(
 )
 ```
 
-### Default values
+### Required and optional arguments
 
-Most primitive types have default values, like `0` for `Int`, or `false`
-for `Double`. Options default to `None`, and sequences to `Nil`.
-Full list in the [source](https://github.com/alexarchambault/case-app/blob/master/src/main/scala/caseapp/core/Default.scala).
+All arguments are required by default. To define an optional argument simply
+wrap its type into `Option[T]`.
+
+Optional arguments can also be defined by providing a default value.
+There are two ways to do that:
+- providing default value ad hoc in the case class definition
+- defining default value for a type with [Default](https://github.com/alexarchambault/case-app/blob/master/src/main/scala/caseapp/core/Default.scala) 
+type class
 
 ```tut:silent
 case class Options(
   user: Option[String],
-  enableFoo: Boolean,
-  file: List[String]
+  enableFoo: Boolean = false,
+  file: List[String] = Nil
 )
 
 CaseApp.parse[Options](Seq()) == Right((Options(None, false, Nil), Seq.empty))
@@ -59,22 +64,6 @@ assert(
 )
 ```
 
-Alternatively, default values can be manually specified, like
-```tut:silent
-case class Options(
-  user: String = "default",
-  enableFoo: Boolean = true
-)
-
-CaseApp.parse[Options](Seq()) == Right((Options("default", true), Seq.empty))
-```
-
-```tut:invisible
-assert(
-  CaseApp.parse[Options](Seq()) == Right((Options("default", true), Seq.empty))
-)
-```
-
 ### Lists
 
 Some arguments can be specified several times on the command-line. These
@@ -83,7 +72,7 @@ should be typed as lists, e.g. `file` in
 ```tut:silent
 case class Options(
   user: Option[String],
-  enableFoo: Boolean,
+  enableFoo: Boolean = false,
   file: List[String]
 )
 


### PR DESCRIPTION
- those implicits will not be applied by default
- Default implicits can be imported where it is needed
- parameter is required until default value is specified in case class constructor or Default implicit is in scope