### PR TITLE
Fall back to arg-parser description in help messages.

### DIFF
--- a/core/shared/src/main/scala/caseapp/core/parser/HListParserBuilder.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/HListParserBuilder.scala
@@ -123,7 +123,7 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
       val arg = Arg(
         Name(name.value.name),
         names.head,
-        valueDescriptions.head,
+        valueDescriptions.head.orElse(Some(new ValueDescription(argParser.value.description))),
         helpMessages.head,
         noHelp.head.nonEmpty,
         argParser.value.isFlag

--- a/core/shared/src/main/scala/caseapp/core/parser/LowPriorityHListParserBuilder.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/LowPriorityHListParserBuilder.scala
@@ -69,7 +69,7 @@ abstract class LowPriorityHListParserBuilder {
       val arg = Arg(
         Name(name.value.name),
         names.head,
-        valueDescriptions.head,
+        valueDescriptions.head.orElse(Some(new ValueDescription(argParser.value.description))),
         helpMessages.head,
         noHelp.head.nonEmpty,
         argParser.value.isFlag

--- a/tests/shared/src/test/scala/caseapp/Definitions.scala
+++ b/tests/shared/src/test/scala/caseapp/Definitions.scala
@@ -41,6 +41,7 @@ object Definitions {
       Right(Custom(arg))
     }
 
+  @AppName("WithCustom")
   final case class WithCustom(
     custom   : Custom = Custom("")
   )


### PR DESCRIPTION
This addresses the 3rd point from #39 (not sure if it qualifies as a "fix" since it relies on sane descriptions in the arg parsers, but in practice it seems pretty good).