### PR TITLE
Document 1.2.0 breaking changes.

### DIFF
--- a/notes/1.2.0.markdown
+++ b/notes/1.2.0.markdown
@@ -1,0 +1,5 @@
+### Changes
+
+- `ArgParser.instance[T](a => b)` now takes a `hintDescription: String`.
+  Use `ArgParser.instance[T]("hint")(a => b)` instead.
+- `WithHelp.base: T` is now `WithHelp.baseOrError: Either[String, T]`


### PR DESCRIPTION
I was upgrading to 1.2.0 in scalafix (due to regression in 2.11.2
related to shapeless) and digged through the v1.1.3..v1.2.0 diff
to see the changes.