### PR TITLE
Updated version in README according to current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ ambiguities with custom types as above.
 Add to your `build.sbt`
 ```scala
 resolvers += Resolver.sonatypeRepo("releases")
-libraryDependencies += "com.github.alexarchambault" %% "case-app" % "1.2.0-M4"
+libraryDependencies += "com.github.alexarchambault" %% "case-app" % "2.0.0-M3"
 ```
 
 Note that case-app depends on shapeless 2.3. Use the `1.0.0` version if you depend on shapeless 2.2.

--- a/doc/readme/README.md
+++ b/doc/readme/README.md
@@ -358,7 +358,7 @@ ambiguities with custom types as above.
 Add to your `build.sbt`
 ```scala
 resolvers += Resolver.sonatypeRepo("releases")
-libraryDependencies += "com.github.alexarchambault" %% "case-app" % "1.2.0-M4"
+libraryDependencies += "com.github.alexarchambault" %% "case-app" % "2.0.0-M3"
 ```
 
 Note that case-app depends on shapeless 2.3. Use the `1.0.0` version if you depend on shapeless 2.2.


### PR DESCRIPTION
The case-app version in the "Usage" section of the README was not up to date.

I found this quite confusing when I was using case-app recently because I didn't double check that I had the correct version installed.

I'm not sure how the build / publishing process works with tut. I changed the version to the currently available Maven Central released version under `docs` and ran `sbt compile`. I hope I did the changes correctly, otherwise please let me know so I can do it properly.