### PR TITLE
fix adaptation of argument list warnings

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -31,8 +31,8 @@ object Settings {
   )
 
   lazy val dontPublish = Seq(
-    publish := (),
-    publishLocal := (),
+    publish := (()),
+    publishLocal := (()),
     publishArtifact := false
   )
 


### PR DESCRIPTION
https://travis-ci.org/alexarchambault/case-app/jobs/468349740#L2851

```
[warn] /home/travis/build/alexarchambault/case-app/project/Settings.scala:34:13: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
[warn]         signature: DefinableTask.:=(v: S): sbt.Def.Setting[sbt.Task[S]]
[warn]   given arguments: <none>
[warn]  after adaptation: DefinableTask.:=((): Unit)
[warn]     publish := (),
[warn]             ^
[warn] /home/travis/build/alexarchambault/case-app/project/Settings.scala:35:18: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
[warn]         signature: DefinableTask.:=(v: S): sbt.Def.Setting[sbt.Task[S]]
[warn]   given arguments: <none>
[warn]  after adaptation: DefinableTask.:=((): Unit)
[warn]     publishLocal := (),
[warn]                  ^
[warn] two warnings found
```