### PR TITLE
Support custom name formatter when using withHelp

### DIFF
--- a/core/shared/src/main/scala/caseapp/core/parser/Parser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/Parser.scala
@@ -189,7 +189,7 @@ abstract class Parser[T] {
     */
   final def withHelp: Parser[WithHelp[T]] = {
     implicit val parser: Parser.Aux[T, D] = this
-    val p = Parser[WithHelp[T]]
+    val p = ParserWithNameFormatter(Parser[WithHelp[T]], defaultNameFormatter)
     if (defaultStopAtFirstUnrecognized)
       p.stopAtFirstUnrecognized
     else

--- a/tests/shared/src/test/scala/caseapp/Tests.scala
+++ b/tests/shared/src/test/scala/caseapp/Tests.scala
@@ -433,6 +433,22 @@ object Tests extends TestSuite {
       assert(res == expectedRes)
     }
 
+    "parser withHelp works with custom option formatter" - {
+      val res =
+        Parser[FewArgs]
+          .nameFormatter((n: Name) => n.name)
+          .withHelp
+          .detailedParse(
+            Seq("--value", "b", "--numFoo", "1")
+          )
+
+      val expectedRes =
+        Right(
+          (WithHelp(false, false, Right(FewArgs("b",1))), RemainingArgs(List(), List()))
+        )
+      assert(res == expectedRes)
+    }
+
   }
 
 }

--- a/tests/shared/src/test/scala/caseapp/Tests.scala
+++ b/tests/shared/src/test/scala/caseapp/Tests.scala
@@ -444,7 +444,7 @@ object Tests extends TestSuite {
 
       val expectedRes =
         Right(
-          (WithHelp(false, false, Right(FewArgs("b",1))), RemainingArgs(List(), List()))
+          (WithHelp(false, false, Right(FewArgs("b", 1))), RemainingArgs(List(), List()))
         )
       assert(res == expectedRes)
     }


### PR DESCRIPTION
Hi @alexarchambault I missed the `withHelp` case.