### PR TITLE
Add .derive methods on most type classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.bsp/
 .idea
 .idea_modules
 *.swp

--- a/core/shared/src/main/scala/caseapp/core/commandparser/AutoCommandParserImplicits.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/AutoCommandParserImplicits.scala
@@ -37,4 +37,11 @@ abstract class AutoCommandParserImplicits {
    ): CommandParser[S] =
     underlying.value.map(lgen.from)
 
+  def derive[S, C <: Coproduct]
+   (implicit
+    lgen: LabelledGeneric.Aux[S, C],
+    underlying: Strict[CommandParser[C]]
+   ): CommandParser[S] =
+    generic[S, C](lgen, underlying)
+
 }

--- a/core/shared/src/main/scala/caseapp/core/help/CommandsHelp.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/CommandsHelp.scala
@@ -57,6 +57,13 @@ object CommandsHelp {
    ): CommandsHelp[S] =
     CommandsHelp(underlying.value.messages)
 
+  def derive[S, C <: Coproduct]
+   (implicit
+     gen: LabelledGeneric.Aux[S, C],
+     underlying: Strict[CommandsHelp[C]]
+   ): CommandsHelp[S] =
+    generic[S, C](gen, underlying)
+
 
   implicit def toCommandsHelpOps[T <: Coproduct](commandsHelp: CommandsHelp[T]): CommandsHelpOps[T] =
     new CommandsHelpOps(commandsHelp)

--- a/core/shared/src/main/scala/caseapp/core/help/Help.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/Help.scala
@@ -132,6 +132,26 @@ object Help {
 
   // FIXME Not sure Typeable is fine on Scala JS, should be replaced by something else
 
+  def derive[T]
+   (implicit
+     parser: Parser[T],
+     typeable: Typeable[T],
+     appName: AnnotationOption[AppName, T],
+     appVersion: AnnotationOption[AppVersion, T],
+     progName: AnnotationOption[ProgName, T],
+     argsName: AnnotationOption[ArgsName, T],
+     helpMessage: AnnotationOption[HelpMessage, T],
+   ): Help[T] =
+    help[T](
+      parser,
+      typeable,
+      appName,
+      appVersion,
+      progName,
+      argsName,
+      helpMessage
+    )
+
   /** Implicitly derives a `Help[T]` for `T` */
   implicit def help[T]
    (implicit
@@ -141,7 +161,7 @@ object Help {
      appVersion: AnnotationOption[AppVersion, T],
      progName: AnnotationOption[ProgName, T],
      argsName: AnnotationOption[ArgsName, T],
-     helpMessage: AnnotationOption[HelpMessage, T], 
+     helpMessage: AnnotationOption[HelpMessage, T],
    ): Help[T] = {
 
     val appName0 = appName().fold(typeable.describe.stripSuffix("Options"))(_.appName)

--- a/core/shared/src/main/scala/caseapp/core/parser/HListParserBuilder.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/HListParserBuilder.scala
@@ -136,7 +136,6 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
   implicit def hconsRecursive[
      K <: Symbol,
      H,
-    HD,
      T <: HList,
     PT <: HList,
     DT <: HList,
@@ -146,7 +145,7 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
     HT <: HList,
     RT <: HList
   ](implicit
-     headParser: Strict[Parser.Aux[H, HD]],
+     headParser: Strict[Parser[H]],
      tail: Aux[T, DT, NT, VT, MT, HT, RT, PT]
    ): Aux[
     FieldType[K, H] :: T,
@@ -156,7 +155,7 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
     None.type :: MT,
     None.type :: HT,
     Some[Recurse] :: RT,
-    HD :: PT
+    headParser.value.D :: PT
   ] =
     instance { (default0, names, valueDescriptions, helpMessages, noHelp) =>
 

--- a/core/shared/src/main/scala/caseapp/core/parser/LowPriorityParserImplicits.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/LowPriorityParserImplicits.scala
@@ -6,6 +6,31 @@ import shapeless.{Annotations, HList, LabelledGeneric, Strict}
 
 abstract class LowPriorityParserImplicits {
 
+  def derive[
+    CC,
+    L <: HList,
+    D <: HList,
+    N <: HList,
+    V <: HList,
+    M <: HList,
+    H <: HList,
+    R <: HList,
+    P <: HList
+  ](implicit
+    gen: LabelledGeneric.Aux[CC, L],
+    defaults: caseapp.util.Default.AsOptions.Aux[CC, D],
+    names: AnnotationList.Aux[Name, CC, N],
+    valuesDesc: Annotations.Aux[ValueDescription, CC, V],
+    helpMessages: Annotations.Aux[HelpMessage, CC, M],
+    noHelp: Annotations.Aux[Hidden, CC, H],
+    recurse: Annotations.Aux[Recurse, CC, R],
+    parser: Strict[HListParserBuilder.Aux[L, D, N, V, M, H, R, P]]
+  ): Parser.Aux[CC, P] =
+    parser
+      .value
+      .apply(defaults(), names(), valuesDesc(), helpMessages(), noHelp())
+      .map(gen.from)
+
   implicit def generic[
     CC,
     L <: HList,
@@ -27,9 +52,15 @@ abstract class LowPriorityParserImplicits {
     recurse: Annotations.Aux[Recurse, CC, R],
     parser: Strict[HListParserBuilder.Aux[L, D, N, V, M, H, R, P]]
   ): Parser.Aux[CC, P] =
-    parser
-      .value
-      .apply(defaults(), names(), valuesDesc(), helpMessages(), noHelp())
-      .map(gen.from)
+    derive[CC, L, D, N, V, M, H, R, P](
+      gen,
+      defaults,
+      names,
+      valuesDesc,
+      helpMessages,
+      noHelp,
+      recurse,
+      parser
+    )
 
 }

--- a/core/shared/src/main/scala/caseapp/package.scala
+++ b/core/shared/src/main/scala/caseapp/package.scala
@@ -12,8 +12,14 @@ package object caseapp {
   type Parser[T] = core.parser.Parser[T]
   val Parser = core.parser.Parser
 
+  type Help[T] = core.help.Help[T]
+  val Help = core.help.Help
+
   type CommandParser[T] = core.commandparser.CommandParser[T]
   val CommandParser = core.commandparser.CommandParser
+
+  type CommandsHelp[T] = core.help.CommandsHelp[T]
+  val CommandsHelp = core.help.CommandsHelp
 
 
   type CaseApp[T] = core.app.CaseApp[T]

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -17,7 +17,7 @@ object Settings {
   }
 
   lazy val shared = Seq(
-    scalaVersion := scala212,
+    scalaVersion := scala213,
     crossScalaVersions := Seq(scala212, scala213),
     scalacOptions ++= Seq(
       "-target:jvm-1.8",

--- a/tests/shared/src/test/scala/caseapp/demo/Demo.scala
+++ b/tests/shared/src/test/scala/caseapp/demo/Demo.scala
@@ -4,14 +4,29 @@ package demo
 import caseapp.core.app.CommandAppA
 import caseapp.core.util.Formatter
 
+final case class SharedOptions(
+  other: String = ""
+)
+
+object SharedOptions {
+  implicit val parser: Parser[SharedOptions] = Parser.derive
+  implicit val help: Help[SharedOptions] = Help.derive
+}
+
 @AppVersion("0.1.0")
 @ArgsName("files")
 final case class DemoOptions(
   first: Boolean,
   @ExtraName("V") @HelpMessage("Set a value") value : Option[String],
   @ExtraName("v") @HelpMessage("Be verbose") verbose : Int @@ Counter,
-  @ExtraName("S") @ValueDescription("stages")  stages : List[String]
+  @ExtraName("S") @ValueDescription("stages")  stages : List[String],
+  @Recurse shared: SharedOptions = SharedOptions()
 )
+
+object DemoOptions {
+  implicit val parser: Parser[DemoOptions] = Parser.derive
+  implicit val help: Help[DemoOptions] = Help.derive
+}
 
 object Demo extends CaseApp[DemoOptions] {
 

--- a/tests/shared/src/test/scala/caseapp/demo/Demo.scala
+++ b/tests/shared/src/test/scala/caseapp/demo/Demo.scala
@@ -2,7 +2,6 @@ package caseapp
 package demo
 
 import caseapp.core.app.CommandAppA
-import caseapp.core.help.CommandsHelp
 import caseapp.core.util.Formatter
 
 @AppVersion("0.1.0")


### PR DESCRIPTION
So that their implicits can have explicit types, like
```scala
implicit val parser: Parser[Options] = Parser.derive
```
rather than
```scala
implicit val parser = Parser[Options]
```