### PR TITLE
Have the 'completions' command accept 'bash' or 'zsh' as format argument

### DIFF
--- a/core/shared/src/main/scala/caseapp/core/app/CommandsEntryPoint.scala
+++ b/core/shared/src/main/scala/caseapp/core/app/CommandsEntryPoint.scala
@@ -37,8 +37,8 @@ abstract class CommandsEntryPoint extends PlatformCommandsMethods {
 
     def script(format: String): String =
       format match {
-        case Bash.id => Bash.script(progName)
-        case Zsh.id => Zsh.script(progName)
+        case Bash.shellName | Bash.id => Bash.script(progName)
+        case Zsh.shellName | Zsh.id => Zsh.script(progName)
         case _ =>
           System.err.println(s"Unrecognized completion format '$format'")
           PlatformUtil.exit(1)

--- a/core/shared/src/main/scala/caseapp/core/complete/Bash.scala
+++ b/core/shared/src/main/scala/caseapp/core/complete/Bash.scala
@@ -2,8 +2,10 @@ package caseapp.core.complete
 
 object Bash {
 
+  val shellName: String =
+    "bash"
   val id: String =
-    "bash-v1"
+    s"$shellName-v1"
 
   def script(progName: String): String =
    s"""#/usr/bin/env bash

--- a/core/shared/src/main/scala/caseapp/core/complete/Zsh.scala
+++ b/core/shared/src/main/scala/caseapp/core/complete/Zsh.scala
@@ -10,8 +10,10 @@ import scala.collection.mutable
 
 object Zsh {
 
+  val shellName: String =
+    "zsh"
   val id: String =
-    "zsh-v1"
+    s"$shellName-v1"
 
   def script(progName: String): String =
    s"""#compdef _$progName $progName


### PR DESCRIPTION
Along with 'bash-v1' and 'zsh-v1'.