### PR TITLE
Various changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,25 @@ jobs:
         jvm: 8
         apps: sbt-launcher:1.2.22
     - name: Test
-      run: sbt ++${{ matrix.SCALA_VERSION }} test mimaReportBinaryIssues
+      run: sbt ++${{ matrix.SCALA_VERSION }} test
+
+  bin-compat:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.1
+    - uses: laughedelic/coursier-setup@v1
+      with:
+        jvm: 8
+        apps: sbt-launcher:1.2.22
+    - name: Test
+      run: sbt +mimaReportBinaryIssues
 
   publish:
-    needs: test
+    needs: [test, bin-compat]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/cats/shared/src/main/scala/caseapp/cats/IOCommandApp.scala
+++ b/cats/shared/src/main/scala/caseapp/cats/IOCommandApp.scala
@@ -5,6 +5,7 @@ import caseapp.core.Error
 import caseapp.core.help.CommandsHelp
 import cats.effect.{ExitCode, IO}
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class IOCommandApp[T](implicit
   commandParser: CommandParser[T],
   commandsMessages: CommandsHelp[T]

--- a/cats/shared/src/main/scala/caseapp/cats/IOCommandAppA.scala
+++ b/cats/shared/src/main/scala/caseapp/cats/IOCommandAppA.scala
@@ -6,6 +6,7 @@ import caseapp.core.RemainingArgs
 import cats.effect.{ExitCode, IO}
 
 /* The A suffix stands for anonymous */
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class IOCommandAppA[T](implicit
   commandParser: CommandParser[T],
   commandsMessages: CommandsHelp[T]

--- a/cats/shared/src/main/scala/caseapp/cats/IOCommandAppWithPreCommand.scala
+++ b/cats/shared/src/main/scala/caseapp/cats/IOCommandAppWithPreCommand.scala
@@ -7,6 +7,7 @@ import caseapp.core.parser.Parser
 import caseapp.core.RemainingArgs
 import cats.effect._
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class IOCommandAppWithPreCommand[D, T](implicit
   val beforeCommandParser: Parser[D],
   baseBeforeCommandMessages: Help[D],

--- a/core/shared/src/main/scala/caseapp/core/Arg.scala
+++ b/core/shared/src/main/scala/caseapp/core/Arg.scala
@@ -21,8 +21,14 @@ import dataclass._
   noHelp: Boolean = false,
   isFlag: Boolean = false,
   @since
-  group: Option[Group] = None
-)
+  group: Option[Group] = None,
+  @since
+  origin: Option[String] = None
+) {
+  def withDefaultOrigin(defaultOrigin: String): Arg =
+    if (origin.isEmpty) withOrigin(Some(defaultOrigin))
+    else this
+}
 
 object Arg {
   def apply(name: String): Arg =

--- a/core/shared/src/main/scala/caseapp/core/app/CommandApp.scala
+++ b/core/shared/src/main/scala/caseapp/core/app/CommandApp.scala
@@ -3,6 +3,7 @@ package caseapp.core.app
 import caseapp.core.commandparser.CommandParser
 import caseapp.core.help.CommandsHelp
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class CommandApp[T](implicit
   commandParser: CommandParser[T],
   commandsMessages: CommandsHelp[T]

--- a/core/shared/src/main/scala/caseapp/core/app/CommandAppA.scala
+++ b/core/shared/src/main/scala/caseapp/core/app/CommandAppA.scala
@@ -5,6 +5,7 @@ import caseapp.core.commandparser.CommandParser
 import caseapp.core.help.CommandsHelp
 
 /* The A suffix stands for anonymous */
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class CommandAppA[T](
   commandParser: CommandParser[T],
   commandsMessages: CommandsHelp[T]

--- a/core/shared/src/main/scala/caseapp/core/app/CommandAppWithPreCommand.scala
+++ b/core/shared/src/main/scala/caseapp/core/app/CommandAppWithPreCommand.scala
@@ -6,6 +6,7 @@ import caseapp.core.help.{CommandsHelp, Help, WithHelp}
 import caseapp.core.parser.Parser
 import caseapp.core.RemainingArgs
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class CommandAppWithPreCommand[D, T](implicit
   val beforeCommandParser: Parser[D],
   baseBeforeCommandMessages: Help[D],

--- a/core/shared/src/main/scala/caseapp/core/app/CommandsEntryPoint.scala
+++ b/core/shared/src/main/scala/caseapp/core/app/CommandsEntryPoint.scala
@@ -17,8 +17,8 @@ abstract class CommandsEntryPoint extends PlatformCommandsMethods {
     RuntimeCommandsHelp(
       progName,
       Some(description).filter(_.nonEmpty),
-      defaultCommand.map(_.messages.withHelp: Help[_]).getOrElse(Help[Unit]()),
-      commands.map(cmd => RuntimeCommandHelp(cmd.names, cmd.messages.withHelp, cmd.group, cmd.hidden))
+      defaultCommand.map(_.finalHelp: Help[_]).getOrElse(Help[Unit]()),
+      commands.map(cmd => RuntimeCommandHelp(cmd.names, cmd.finalHelp, cmd.group, cmd.hidden))
     )
 
   def helpFormat: HelpFormat =
@@ -100,7 +100,7 @@ abstract class CommandsEntryPoint extends PlatformCommandsMethods {
         case None =>
           RuntimeCommandParser.parse(commands, actualArgs.toList) match {
             case None =>
-              val usage = help.help(helpFormat)
+              val usage = help.help(helpFormat, showHidden = false)
               println(usage)
               PlatformUtil.exit(0)
             case Some((commandName, command, commandArgs)) =>

--- a/core/shared/src/main/scala/caseapp/core/commandparser/AutoCommandParserImplicits.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/AutoCommandParserImplicits.scala
@@ -7,6 +7,7 @@ import caseapp.util.AnnotationOption
 import shapeless.{:+:, CNil, Coproduct, LabelledGeneric, Strict, Witness}
 import shapeless.labelled.{FieldType, field}
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class AutoCommandParserImplicits {
 
   implicit def cnil: CommandParser[CNil] =

--- a/core/shared/src/main/scala/caseapp/core/commandparser/CommandParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/CommandParser.scala
@@ -15,6 +15,7 @@ import scala.annotation.tailrec
   *
   * @tparam T: result type
   */
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 abstract class CommandParser[T] {
 
   /**
@@ -141,6 +142,7 @@ abstract class CommandParser[T] {
 
 }
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 object CommandParser extends AutoCommandParserImplicits {
 
   def apply[T](implicit parser: CommandParser[T]): CommandParser[T] = parser

--- a/core/shared/src/main/scala/caseapp/core/commandparser/CommandParserOps.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/CommandParserOps.scala
@@ -4,6 +4,7 @@ import caseapp.core.app.CaseApp
 import caseapp.core.parser.Parser
 import shapeless.{:+:, Coproduct, Generic, ops}
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 final class CommandParserOps[T <: Coproduct](val commandParser: CommandParser[T]) extends AnyVal {
 
   // foo added not to collide with the other add method below

--- a/core/shared/src/main/scala/caseapp/core/commandparser/ConsCommandParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/ConsCommandParser.scala
@@ -4,6 +4,7 @@ import caseapp.core.parser.Parser
 import dataclass.data
 import shapeless.{:+:, Coproduct, Inl, Inr}
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 @data class ConsCommandParser[H, T <: Coproduct](
   name: Seq[String],
   parser: Parser[H],

--- a/core/shared/src/main/scala/caseapp/core/commandparser/MappedCommandParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/MappedCommandParser.scala
@@ -3,6 +3,7 @@ package caseapp.core.commandparser
 import caseapp.core.parser.Parser
 import dataclass.data
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 @data class MappedCommandParser[T, U](parser: CommandParser[T], f: T => U) extends CommandParser[U] {
 
   def commandMap: Map[Seq[String], Parser[U]] =

--- a/core/shared/src/main/scala/caseapp/core/commandparser/NilCommandParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/NilCommandParser.scala
@@ -3,6 +3,7 @@ package caseapp.core.commandparser
 import caseapp.core.parser.Parser
 import shapeless.CNil
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 case object NilCommandParser extends CommandParser[CNil] {
 
   def commandMap: Map[Seq[String], Parser[CNil]] =

--- a/core/shared/src/main/scala/caseapp/core/commandparser/WithHelpCommandParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/commandparser/WithHelpCommandParser.scala
@@ -4,6 +4,7 @@ import caseapp.core.parser.Parser
 import caseapp.core.help.WithHelp
 import dataclass.data
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 @data class WithHelpCommandParser[T](parser: CommandParser[T]) extends CommandParser[WithHelp[T]] {
 
   def commandMap: Map[Seq[String], Parser[WithHelp[T]]] =

--- a/core/shared/src/main/scala/caseapp/core/complete/Completer.scala
+++ b/core/shared/src/main/scala/caseapp/core/complete/Completer.scala
@@ -1,7 +1,7 @@
 package caseapp.core.complete
 
 import caseapp.core.Arg
-import caseapp.core.help.WithHelp
+import caseapp.core.help.{WithFullHelp, WithHelp}
 
 trait Completer[T] { self =>
   def optionName(prefix: String, state: Option[T]): List[CompletionItem]
@@ -18,5 +18,7 @@ trait Completer[T] { self =>
         self.argument(prefix, state.flatMap(f))
     }
   def withHelp: Completer[WithHelp[T]] =
+    contramapOpt(_.baseOrError.toOption)
+  def withFullHelp: Completer[WithFullHelp[T]] =
     contramapOpt(_.baseOrError.toOption)
 }

--- a/core/shared/src/main/scala/caseapp/core/help/CommandsHelp.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/CommandsHelp.scala
@@ -11,6 +11,7 @@ import scala.language.implicitConversions
 import caseapp.HelpMessage
 
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 @data class CommandsHelp[T](
   messages: Seq[(Seq[String], CommandHelp)]
 ) {
@@ -20,6 +21,7 @@ import caseapp.HelpMessage
     CommandsHelp(messages)
 }
 
+@deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
 object CommandsHelp {
 
   def apply[T](implicit messages: CommandsHelp[T]): CommandsHelp[T] = messages

--- a/core/shared/src/main/scala/caseapp/core/help/HelpFormat.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/HelpFormat.scala
@@ -14,7 +14,9 @@ import dataclass._
   sortedGroups: Option[Seq[String]] = None,
   @since("2.1.0")
   sortCommandGroups: Option[Seq[String] => Seq[String]] = None,
-  sortedCommandGroups: Option[Seq[String]] = None
+  sortedCommandGroups: Option[Seq[String]] = None,
+  @since("2.1.0")
+  hidden: fansi.Attrs = fansi.Attrs.Empty
 ) {
   private def sortValues[T](
     sortGroups: Option[Seq[String] => Seq[String]],
@@ -49,6 +51,7 @@ object HelpFormat {
         .withProgName(fansi.Bold.On)
         .withCommandName(fansi.Bold.On)
         .withOption(fansi.Color.Yellow)
+        .withHidden(fansi.Color.DarkGray)
     else
       HelpFormat()
 }

--- a/core/shared/src/main/scala/caseapp/core/help/WithFullHelp.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/WithFullHelp.scala
@@ -1,0 +1,23 @@
+package caseapp.core.help
+
+import caseapp.core.Error
+import caseapp.{ExtraName, Group, HelpMessage, Recurse}
+
+final case class WithFullHelp[T](
+  @Group("Help")
+  @HelpMessage("Print usage and exit")
+    usage: Boolean = false,
+  @Group("Help")
+  @HelpMessage("Print help message and exit")
+  @ExtraName("h")
+    help: Boolean = false,
+  @Group("Help")
+  @HelpMessage("Print help message, including hidden options, and exit")
+  @ExtraName("fullHelp")
+    helpFull: Boolean = false,
+  @Recurse
+    baseOrError: Either[Error, T]
+) {
+  def map[U](f: T => U): WithFullHelp[U] =
+    copy(baseOrError = baseOrError.map(f))
+}

--- a/core/shared/src/main/scala/caseapp/core/parser/Argument.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/Argument.scala
@@ -10,8 +10,11 @@ import caseapp.Name
 @data class Argument[H](
   arg: Arg,
   argParser: ArgParser[H],
-  default: () => Option[H]
+  default: () => Option[H] // FIXME Couldn't this be Option[() => H]?
 ) {
+
+  def withDefaultOrigin(origin: String): Argument[H] =
+    withArg(arg.withDefaultOrigin(origin))
 
   def init: Option[H] =
     None

--- a/core/shared/src/main/scala/caseapp/core/parser/Argument.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/Argument.scala
@@ -1,87 +1,29 @@
 package caseapp.core.parser
 
-import caseapp.core.argparser.{ArgParser, Consumed}
+import caseapp.core.argparser.ArgParser
 import caseapp.core.{Arg, Error}
-import caseapp.core.util.NameOps.toNameOps
-import dataclass.data
 import caseapp.core.util.Formatter
 import caseapp.Name
 
-@data class Argument[H](
-  arg: Arg,
-  argParser: ArgParser[H],
-  default: () => Option[H] // FIXME Couldn't this be Option[() => H]?
-) {
-
-  def withDefaultOrigin(origin: String): Argument[H] =
-    withArg(arg.withDefaultOrigin(origin))
-
-  def init: Option[H] =
-    None
-
+trait Argument[H] {
+  def arg: Arg
+  def withDefaultOrigin(origin: String): Argument[H]
+  def init: Option[H]
   def step(
       args: List[String],
       d: Option[H],
       nameFormatter: Formatter[Name]
-  ): Either[(Error, List[String]), Option[(Option[H], List[String])]] =
-    args match {
-      case Nil =>
-        Right(None)
-
-      case firstArg :: rem =>
-        val matchedOpt = (Iterator(arg.name) ++ arg.extraNames.iterator)
-          .map(n => n -> n(firstArg, nameFormatter))
-          .collectFirst {
-            case (n, Right(valueOpt)) => n -> valueOpt
-          }
-
-        matchedOpt match {
-          case Some((name, valueOpt)) =>
-
-            val (res, rem0) = valueOpt match {
-              case Some(value) =>
-                val res0 = argParser(d, value)
-                  .map(h => Some(Some(h)))
-                (res0, rem)
-              case None =>
-                rem match {
-                  case Nil =>
-                    val res0 = argParser(d)
-                      .map(h => Some(Some(h)))
-                    (res0, Nil)
-                  case th :: tRem =>
-                    val (Consumed(usedArg), res) = argParser.optional(d, th)
-                    val res0 = res.map(h => Some(Some(h)))
-                    (res0, if (usedArg) tRem else rem)
-                }
-            }
-
-            res
-              .left
-              .map { err =>
-                (Error.ParsingArgument(name, err, nameFormatter), rem0)
-              }
-              .map(_.map((_, rem0)))
-
-          case None =>
-            Right(None)
-        }
-    }
-
-  def get(d: Option[H], nameFormatter: Formatter[Name]): Either[Error, H] =
-    d.orElse(default()).toRight {
-      Error.RequiredOptionNotSpecified(
-        arg.name.option(nameFormatter),
-        arg.extraNames.map(_.option(nameFormatter))
-      )
-    }
-
-  val args: Seq[Arg] =
-    Seq(arg)
-
+  ): Either[(Error, List[String]), Option[(Option[H], List[String])]]
+  def get(d: Option[H], nameFormatter: Formatter[Name]): Either[Error, H]
 }
 
 object Argument {
   def apply[H: ArgParser](arg: Arg): Argument[H] =
-    Argument[H](arg, ArgParser[H], () => None)
+    StandardArgument[H](arg)
+  def apply[H](
+    arg: Arg,
+    argParser: ArgParser[H],
+    default: () => Option[H]
+  ): StandardArgument[H] =
+    StandardArgument[H](arg, argParser, default)
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/ConsParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/ConsParser.scala
@@ -68,4 +68,7 @@ import caseapp.Name
       this
     )
 
+  def withDefaultOrigin(origin: String): Parser.Aux[H :*: T, D] =
+    withArg(arg.withDefaultOrigin(origin))
+      .withTail(tail.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/ConsParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/ConsParser.scala
@@ -9,13 +9,9 @@ import caseapp.core.util.Formatter
 import caseapp.Name
 
 @data class ConsParser[H, T <: HList, DT <: HList](
-  arg: Arg,
-  argParser: ArgParser[H],
-  default: () => Option[H], // FIXME Couldn't this be Option[() => H]?
+  argument: Argument[H],
   tail: Parser.Aux[T, DT]
 ) extends Parser[H :*: T] {
-
-  private val argument = Argument(arg, argParser, default)
 
   type D = Option[H] :*: DT
 
@@ -28,9 +24,9 @@ import caseapp.Name
       nameFormatter: Formatter[Name]
   ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
     argument.step(args, d.head, nameFormatter) match {
-      case Left((err, rem)) => Left((err, arg, rem))
+      case Left((err, rem)) => Left((err, argument.arg, rem))
       case Right(Some((dHead, rem))) =>
-        Right(Some((dHead :: d.tail, arg, rem)))
+        Right(Some((dHead :: d.tail, argument.arg, rem)))
       case Right(None) =>
         tail
           .step(args, d.tail, nameFormatter)
@@ -53,7 +49,7 @@ import caseapp.Name
   }
 
   val args: Seq[Arg] =
-    arg +: tail.args
+    argument.arg +: tail.args
 
   def mapHead[I](f: H => I): Parser.Aux[I :*: T, D] =
     map { l =>
@@ -61,14 +57,9 @@ import caseapp.Name
     }
 
   def ::[A](argument: Argument[A]): ConsParser[A, H :*: T, D] =
-    ConsParser[A, H :*: T, D](
-      argument.arg,
-      argument.argParser,
-      argument.default,
-      this
-    )
+    ConsParser[A, H :*: T, D](argument, this)
 
   def withDefaultOrigin(origin: String): Parser.Aux[H :*: T, D] =
-    withArg(arg.withDefaultOrigin(origin))
+    withArgument(argument.withDefaultOrigin(origin))
       .withTail(tail.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/EitherParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/EitherParser.scala
@@ -33,4 +33,6 @@ import caseapp.Name
   override def defaultNameFormatter: Formatter[Name] =
     underlying.defaultNameFormatter
 
+  def withDefaultOrigin(origin: String): Parser.Aux[Either[Error, T], D] =
+    withUnderlying(underlying.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/HListParserBuilder.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/HListParserBuilder.scala
@@ -138,7 +138,9 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
         groups.head
       )
 
-      ConsParser(arg, argParser.value, () => default0().head.orElse(Some(default.value.value)), tailParser)
+      val argument = Argument(arg, argParser.value, () => default0().head.orElse(Some(default.value.value)))
+
+      ConsParser(argument, tailParser)
         .mapHead(field[K](_))
     }
 

--- a/core/shared/src/main/scala/caseapp/core/parser/IgnoreUnrecognizedParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/IgnoreUnrecognizedParser.scala
@@ -5,8 +5,8 @@ import dataclass.data
 import caseapp.core.util.Formatter
 import caseapp.Name
 
-@data class IgnoreUnrecognizedParser[T](underlying: Parser[T]) extends Parser[T] {
-  type D = underlying.D
+@data class IgnoreUnrecognizedParser[T, D0](underlying: Parser.Aux[T, D0]) extends Parser[T] {
+  type D = D0
   def init: D = underlying.init
   def step(
     args: List[String],
@@ -24,4 +24,7 @@ import caseapp.Name
     true
   override def defaultNameFormatter: Formatter[Name] =
     underlying.defaultNameFormatter
+
+  def withDefaultOrigin(origin: String): Parser.Aux[T, D] =
+    withUnderlying(underlying.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/LowPriorityHListParserBuilder.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/LowPriorityHListParserBuilder.scala
@@ -81,7 +81,9 @@ abstract class LowPriorityHListParserBuilder {
         groups.head
       )
 
-      ConsParser(arg, argParser.value, () => default0().head, tailParser)
+      val argument = Argument(arg, argParser.value, () => default0().head)
+
+      ConsParser(argument, tailParser)
         .mapHead(field[K](_))
     }
 

--- a/core/shared/src/main/scala/caseapp/core/parser/LowPriorityParserImplicits.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/LowPriorityParserImplicits.scala
@@ -2,7 +2,7 @@ package caseapp.core.parser
 
 import caseapp.{HelpMessage, Group, Hidden, Name, Recurse, ValueDescription}
 import caseapp.util.AnnotationList
-import shapeless.{Annotations, HList, LabelledGeneric, Strict}
+import shapeless.{Annotations, HList, LabelledGeneric, Strict, Typeable}
 
 abstract class LowPriorityParserImplicits {
 
@@ -19,6 +19,7 @@ abstract class LowPriorityParserImplicits {
     P <: HList
   ](implicit
     gen: LabelledGeneric.Aux[CC, L],
+    typeable: Typeable[CC],
     defaults: caseapp.util.Default.AsOptions.Aux[CC, D],
     names: AnnotationList.Aux[Name, CC, N],
     valuesDesc: Annotations.Aux[ValueDescription, CC, V],
@@ -32,6 +33,7 @@ abstract class LowPriorityParserImplicits {
       .value
       .apply(defaults(), names(), valuesDesc(), helpMessages(), group(), noHelp())
       .map(gen.from)
+      .withDefaultOrigin(typeable.describe)
 
   implicit def generic[
     CC,
@@ -47,6 +49,7 @@ abstract class LowPriorityParserImplicits {
   ](implicit
     lowPriority: caseapp.util.LowPriority,
     gen: LabelledGeneric.Aux[CC, L],
+    typeable: Typeable[CC],
     defaults: caseapp.util.Default.AsOptions.Aux[CC, D],
     names: AnnotationList.Aux[Name, CC, N],
     valuesDesc: Annotations.Aux[ValueDescription, CC, V],
@@ -58,6 +61,7 @@ abstract class LowPriorityParserImplicits {
   ): Parser.Aux[CC, P] =
     derive[CC, L, D, N, V, M, G, H, R, P](
       gen,
+      typeable,
       defaults,
       names,
       valuesDesc,

--- a/core/shared/src/main/scala/caseapp/core/parser/MappedParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/MappedParser.scala
@@ -35,4 +35,7 @@ import caseapp.Name
 
   override def defaultNameFormatter: Formatter[Name] =
     underlying.defaultNameFormatter
+
+  def withDefaultOrigin(origin: String): Parser.Aux[U, D] =
+    withUnderlying(underlying.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/NilParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/NilParser.scala
@@ -26,12 +26,7 @@ case object NilParser extends Parser[HNil] {
     scala.Nil
 
   def ::[A](argument: Argument[A]): ConsParser[A, HNil, HNil] =
-    ConsParser[A, HNil, HNil](
-      argument.arg,
-      argument.argParser,
-      argument.default,
-      this
-    )
+    ConsParser[A, HNil, HNil](argument, this)
 
   def withDefaultOrigin(origin: String): Parser.Aux[HNil, D] =
     this

--- a/core/shared/src/main/scala/caseapp/core/parser/NilParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/NilParser.scala
@@ -33,4 +33,6 @@ case object NilParser extends Parser[HNil] {
       this
     )
 
+  def withDefaultOrigin(origin: String): Parser.Aux[HNil, D] =
+    this
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/OptionParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/OptionParser.scala
@@ -33,4 +33,7 @@ import caseapp.Name
 
   override def defaultNameFormatter: Formatter[Name] =
     underlying.defaultNameFormatter
+
+  def withDefaultOrigin(origin: String): Parser.Aux[Option[T], D] =
+    withUnderlying(underlying.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/Parser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/Parser.scala
@@ -92,18 +92,18 @@ abstract class Parser[T] {
 
   def defaultStopAtFirstUnrecognized: Boolean =
     false
-  def stopAtFirstUnrecognized: Parser[T] =
+  def stopAtFirstUnrecognized: Parser.Aux[T, D] =
     StopAtFirstUnrecognizedParser(this)
 
   def defaultIgnoreUnrecognized: Boolean =
     false
-  def ignoreUnrecognized: Parser[T] =
+  def ignoreUnrecognized: Parser.Aux[T, D] =
     IgnoreUnrecognizedParser(this)
 
   def defaultNameFormatter: Formatter[Name] =
     Formatter.DefaultNameFormatter
 
-  def nameFormatter(f: Formatter[Name]): Parser[T] =
+  def nameFormatter(f: Formatter[Name]): Parser.Aux[T, D] =
     ParserWithNameFormatter(this, f)
 
   final def parse(args: Seq[String]): Either[Error, (T, Seq[String])] =
@@ -313,6 +313,8 @@ abstract class Parser[T] {
 
   final def map[U](f: T => U): Parser.Aux[U, D] =
     MappedParser(this, f)
+
+  def withDefaultOrigin(origin: String): Parser.Aux[T, D]
 }
 
 object Parser extends LowPriorityParserImplicits {

--- a/core/shared/src/main/scala/caseapp/core/parser/Parser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/Parser.scala
@@ -2,7 +2,7 @@ package caseapp.core.parser
 
 import scala.language.implicitConversions
 import caseapp.core.{Arg, Error}
-import caseapp.core.help.WithHelp
+import caseapp.core.help.{WithFullHelp, WithHelp}
 import caseapp.core.RemainingArgs
 import shapeless.{HList, HNil}
 import caseapp.core.util.Formatter
@@ -330,6 +330,17 @@ abstract class Parser[T] {
   final def withHelp: Parser[WithHelp[T]] = {
     implicit val parser: Parser.Aux[T, D] = this
     val p = ParserWithNameFormatter(Parser[WithHelp[T]], defaultNameFormatter)
+    if (defaultIgnoreUnrecognized)
+      p.ignoreUnrecognized
+    else if (defaultStopAtFirstUnrecognized)
+      p.stopAtFirstUnrecognized
+    else
+      p
+  }
+
+  final def withFullHelp: Parser[WithFullHelp[T]] = {
+    implicit val parser: Parser.Aux[T, D] = this
+    val p = ParserWithNameFormatter(Parser[WithFullHelp[T]], defaultNameFormatter)
     if (defaultIgnoreUnrecognized)
       p.ignoreUnrecognized
     else if (defaultStopAtFirstUnrecognized)

--- a/core/shared/src/main/scala/caseapp/core/parser/ParserOps.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/ParserOps.scala
@@ -18,8 +18,8 @@ class ParserOps[T <: HList, D <: HList](val parser: Parser.Aux[T, D]) extends An
     noHelp: Boolean = false,
     isFlag: Boolean = false,
     formatter: Formatter[Name] = Formatter.DefaultNameFormatter
-  ): Parser.Aux[H :: T, Option[H] :: D] =
-    ConsParser(
+  ): Parser.Aux[H :: T, Option[H] :: D] = {
+    val argument = Argument(
       Arg(
         Name(name),
         extraNames,
@@ -29,9 +29,10 @@ class ParserOps[T <: HList, D <: HList](val parser: Parser.Aux[T, D]) extends An
         isFlag
       ),
       ArgParser[H],
-      () => default,
-      parser
+      () => default
     )
+    ConsParser(argument, parser)
+  }
 
   def addAll[U]: ParserOps.AddAllHelper[T, D, U] =
     new ParserOps.AddAllHelper[T, D, U](parser)

--- a/core/shared/src/main/scala/caseapp/core/parser/ParserWithNameFormatter.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/ParserWithNameFormatter.scala
@@ -5,9 +5,9 @@ import dataclass.data
 import caseapp.core.util.Formatter
 import caseapp.Name
 
-@data class ParserWithNameFormatter[T](underlying: Parser[T], f: Formatter[Name])
+@data class ParserWithNameFormatter[T, D0](underlying: Parser.Aux[T, D0], f: Formatter[Name])
     extends Parser[T] {
-  type D = underlying.D
+  type D = D0
 
   def init: D = underlying.init
 
@@ -30,4 +30,7 @@ import caseapp.Name
     underlying.defaultIgnoreUnrecognized
 
   override def defaultNameFormatter: Formatter[Name] = f
+
+  def withDefaultOrigin(origin: String): Parser.Aux[T, D] =
+    withUnderlying(underlying.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/RecursiveConsParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/RecursiveConsParser.scala
@@ -53,4 +53,7 @@ import dataclass.data
       f(l.head) :: l.tail
     }
 
+  def withDefaultOrigin(origin: String): Parser.Aux[H :: T, D] =
+    withHeadParser(headParser.withDefaultOrigin(origin))
+      .withTailParser(tailParser.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/parser/StandardArgument.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/StandardArgument.scala
@@ -1,0 +1,87 @@
+package caseapp.core.parser
+
+import caseapp.core.argparser.{ArgParser, Consumed}
+import caseapp.core.{Arg, Error}
+import caseapp.core.util.NameOps.toNameOps
+import dataclass.data
+import caseapp.core.util.Formatter
+import caseapp.Name
+
+@data class StandardArgument[H](
+  arg: Arg,
+  argParser: ArgParser[H],
+  default: () => Option[H] // FIXME Couldn't this be Option[() => H]?
+) extends Argument[H] {
+
+  def withDefaultOrigin(origin: String): Argument[H] =
+    withArg(arg.withDefaultOrigin(origin))
+
+  def init: Option[H] =
+    None
+
+  def step(
+      args: List[String],
+      d: Option[H],
+      nameFormatter: Formatter[Name]
+  ): Either[(Error, List[String]), Option[(Option[H], List[String])]] =
+    args match {
+      case Nil =>
+        Right(None)
+
+      case firstArg :: rem =>
+        val matchedOpt = (Iterator(arg.name) ++ arg.extraNames.iterator)
+          .map(n => n -> n(firstArg, nameFormatter))
+          .collectFirst {
+            case (n, Right(valueOpt)) => n -> valueOpt
+          }
+
+        matchedOpt match {
+          case Some((name, valueOpt)) =>
+
+            val (res, rem0) = valueOpt match {
+              case Some(value) =>
+                val res0 = argParser(d, value)
+                  .map(h => Some(Some(h)))
+                (res0, rem)
+              case None =>
+                rem match {
+                  case Nil =>
+                    val res0 = argParser(d)
+                      .map(h => Some(Some(h)))
+                    (res0, Nil)
+                  case th :: tRem =>
+                    val (Consumed(usedArg), res) = argParser.optional(d, th)
+                    val res0 = res.map(h => Some(Some(h)))
+                    (res0, if (usedArg) tRem else rem)
+                }
+            }
+
+            res
+              .left
+              .map { err =>
+                (Error.ParsingArgument(name, err, nameFormatter), rem0)
+              }
+              .map(_.map((_, rem0)))
+
+          case None =>
+            Right(None)
+        }
+    }
+
+  def get(d: Option[H], nameFormatter: Formatter[Name]): Either[Error, H] =
+    d.orElse(default()).toRight {
+      Error.RequiredOptionNotSpecified(
+        arg.name.option(nameFormatter),
+        arg.extraNames.map(_.option(nameFormatter))
+      )
+    }
+
+  val args: Seq[Arg] =
+    Seq(arg)
+
+}
+
+object StandardArgument {
+  def apply[H: ArgParser](arg: Arg): StandardArgument[H] =
+    StandardArgument[H](arg, ArgParser[H], () => None)
+}

--- a/core/shared/src/main/scala/caseapp/core/parser/StopAtFirstUnrecognizedParser.scala
+++ b/core/shared/src/main/scala/caseapp/core/parser/StopAtFirstUnrecognizedParser.scala
@@ -5,8 +5,8 @@ import dataclass.data
 import caseapp.core.util.Formatter
 import caseapp.Name
 
-@data class StopAtFirstUnrecognizedParser[T](underlying: Parser[T]) extends Parser[T] {
-  type D = underlying.D
+@data class StopAtFirstUnrecognizedParser[T, D0](underlying: Parser.Aux[T, D0]) extends Parser[T] {
+  type D = D0
   def init: D = underlying.init
   def step(
       args: List[String],
@@ -24,4 +24,7 @@ import caseapp.Name
     underlying.defaultIgnoreUnrecognized
   override def defaultNameFormatter: Formatter[Name] =
     underlying.defaultNameFormatter
+
+  def withDefaultOrigin(origin: String): Parser.Aux[T, D] =
+    withUnderlying(underlying.withDefaultOrigin(origin))
 }

--- a/core/shared/src/main/scala/caseapp/core/util/NameOps.scala
+++ b/core/shared/src/main/scala/caseapp/core/util/NameOps.scala
@@ -9,11 +9,13 @@ class NameOps(val name: Name) extends AnyVal {
   private def isShort: Boolean =
     name.name.length == 1
 
-  private def optionEq(nameFormatter: Formatter[Name]): String = 
+  private def optionEq(nameFormatter: Formatter[Name]): String =
     option(nameFormatter) + "="
 
   def option(nameFormatter: Formatter[Name]): String =
-    if (isShort) s"-${name.name}" else s"--${nameFormatter.format(name)}"
+    if (name.name.startsWith("-")) nameFormatter.format(name)
+    else if (isShort) s"-${name.name}"
+    else s"--${nameFormatter.format(name)}"
 
   def apply(
       args: List[String],

--- a/core/shared/src/main/scala/caseapp/package.scala
+++ b/core/shared/src/main/scala/caseapp/package.scala
@@ -15,7 +15,9 @@ package object caseapp {
   type Help[T] = core.help.Help[T]
   val Help = core.help.Help
 
+  @deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
   type CommandParser[T] = core.commandparser.CommandParser[T]
+  @deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
   val CommandParser = core.commandparser.CommandParser
 
   type CommandsHelp[T] = core.help.CommandsHelp[T]
@@ -27,6 +29,7 @@ package object caseapp {
 
   type Command[T] = core.app.Command[T]
 
+  @deprecated("Use Command and CommandsEntryPoint instead", "2.1.0")
   type CommandApp[T] = core.app.CommandApp[T]
 
 

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -9,7 +9,7 @@ import scala.sys.process._
 object Mima {
 
   def binaryCompatibilityVersions: Set[String] =
-    Seq("git", "tag", "--merged", "HEAD^", "--contains", "a06e9001")
+    Seq("git", "tag", "--merged", "HEAD^", "--contains", "15cf6005e")
       .!!
       .linesIterator
       .map(_.trim)

--- a/tests/shared/src/test/scala/caseapp/HelpTests.scala
+++ b/tests/shared/src/test/scala/caseapp/HelpTests.scala
@@ -171,6 +171,22 @@ object HelpTests extends TestSuite {
       }
     }
 
+    test("add a help message for fields annotated with @Hidden in full help") {
+
+      val helpLines = Help[Options].help(format, showHidden = true).linesIterator.toVector
+
+      test {
+        val res = helpLines.count(_.contains("--first"))
+        val expectedRes = 1
+        assert(res == expectedRes)
+      }
+      test {
+        val res = helpLines.count(_.contains("--second"))
+        val expectedRes = 1
+        assert(res == expectedRes)
+      }
+    }
+
     test("duplicates") {
 
       import Definitions.Duplicates._
@@ -284,31 +300,55 @@ object HelpTests extends TestSuite {
       assert(help == expected)
     }
 
-    test("hide hidden commands in help message") {
+    test("hidden commands in help message") {
       val entryPoint = new CommandsEntryPoint {
         def progName = "foo"
         override def defaultCommand = Some(HiddenCommands.First)
         def commands = Seq(HiddenCommands.First, HiddenCommands.Second, HiddenCommands.Third)
       }
-      val help = entryPoint.help.help(format)
-      val expected =
-        """Usage: foo <COMMAND> [options]
-          |
-          |Help options:
-          |  --usage     Print usage and exit
-          |  -h, --help  Print help message and exit
-          |
-          |Other options:
-          |  -f, --foo string
-          |  --bar int
-          |
-          |Aa commands:
-          |  third  Third help message
-          |
-          |Bb commands:
-          |  second""".stripMargin
+      test("hidden by default") {
+        val help = entryPoint.help.help(format)
+        val expected =
+          """Usage: foo <COMMAND> [options]
+            |
+            |Help options:
+            |  --usage     Print usage and exit
+            |  -h, --help  Print help message and exit
+            |
+            |Other options:
+            |  -f, --foo string
+            |  --bar int
+            |
+            |Aa commands:
+            |  third  Third help message
+            |
+            |Bb commands:
+            |  second""".stripMargin
 
-      assert(help == expected)
+        assert(help == expected)
+      }
+      test("shown when asked") {
+        val help = entryPoint.help.help(format, showHidden = true)
+        val expected =
+          """Usage: foo <COMMAND> [options]
+            |
+            |Help options:
+            |  --usage     Print usage and exit
+            |  -h, --help  Print help message and exit
+            |
+            |Other options:
+            |  -f, --foo string
+            |  --bar int
+            |
+            |Aa commands:
+            |  first  (hidden)
+            |  third  Third help message
+            |
+            |Bb commands:
+            |  second""".stripMargin
+
+        assert(help == expected)
+      }
     }
 
   }

--- a/tests/shared/src/test/scala/caseapp/ParserTests.scala
+++ b/tests/shared/src/test/scala/caseapp/ParserTests.scala
@@ -1,9 +1,11 @@
 package caseapp
 
-import caseapp.core.Arg
-import caseapp.core.parser.{Argument, NilParser}
-import utest._
+import caseapp.core.{Arg, Error}
+import caseapp.core.parser.{Argument, NilParser, StandardArgument}
 import caseapp.core.parser.ParserOps
+import caseapp.core.util.Formatter
+
+import utest._
 
 object ParserTests extends TestSuite {
   val tests = Tests {
@@ -31,7 +33,7 @@ object ParserTests extends TestSuite {
       case class Helper(n: Int, value: String)
       val parser =
         Argument[Int](Arg("n")) ::
-        Argument[String](Arg("value")).withDefault(() => Some("-")) ::
+        StandardArgument[String](Arg("value")).withDefault(() => Some("-")) ::
           NilParser
       test {
         val res = parser.to[Helper].parse(Seq("-n", "2", "something", "--value", "foo"))
@@ -52,7 +54,7 @@ object ParserTests extends TestSuite {
       case class Helper(n: Int, value: String)
       val parser =
         Argument[Int](Arg("n")) ::
-        Argument[String](Arg("value")).withDefault(() => Some("default")) ::
+        StandardArgument[String](Arg("value")).withDefault(() => Some("default")) ::
           NilParser
       test("single") {
         val res = parser.to[Helper].parse(Seq("-n", "2", "-"))
@@ -81,6 +83,39 @@ object ParserTests extends TestSuite {
       assert(countArg.origin == Some("MoreArgs"))
       assert(valueArg.origin == Some("FewArgs"))
       assert(numFooArg.origin == Some("FewArgs"))
+    }
+
+    test("Custom Argument type") {
+      case class Helper(n: Int, values: List[String])
+
+      val valuesArgument = new Argument[List[String]] {
+        def arg = Arg(Name("X")).withIsFlag(true)
+        def withDefaultOrigin(origin: String): Argument[List[String]] = ???
+        def init: Option[List[String]] = Some(Nil)
+        def step(
+            args: List[String],
+            d: Option[List[String]],
+            nameFormatter: Formatter[Name]
+        ): Either[(Error, List[String]), Option[(Option[List[String]], List[String])]] =
+          args match {
+            case h :: t if h.startsWith("-X") =>
+              Right(Some((Some(h :: d.getOrElse(Nil)), t)))
+            case _ => Right(None)
+          }
+        def get(d: Option[List[String]], nameFormatter: Formatter[Name]): Either[Error, List[String]] =
+          d.map(_.reverse).toRight(
+            Error.RequiredOptionNotSpecified("-X*", Nil)
+          )
+      }
+
+      val parser =
+        Argument[Int](Arg("n")) ::
+        valuesArgument ::
+          NilParser
+
+      val res = parser.to[Helper].parse(Seq("-n", "2", "-Xa", "foo", "-Xb"))
+      val expected = Right((Helper(2, List("-Xa", "-Xb")), List("foo")))
+      assert(res == expected)
     }
   }
 }

--- a/tests/shared/src/test/scala/caseapp/ParserTests.scala
+++ b/tests/shared/src/test/scala/caseapp/ParserTests.scala
@@ -65,5 +65,22 @@ object ParserTests extends TestSuite {
         assert(res == expected)
       }
     }
+
+    test("Retain origin class of options") {
+      val parser = Parser[Definitions.MoreArgs]
+      val args = parser.args
+      val baseMap = args.groupBy(_.name.name)
+      assert(baseMap.size == 3)
+      assert(baseMap.forall(_._2.length == 1))
+      val map = baseMap.map { case (k, v) => (k, v.head) }
+
+      val countArg = map.getOrElse("count", sys.error("count argument not found"))
+      val valueArg = map.getOrElse("value", sys.error("value argument not found"))
+      val numFooArg = map.getOrElse("numFoo", sys.error("numFoo argument not found"))
+
+      assert(countArg.origin == Some("MoreArgs"))
+      assert(valueArg.origin == Some("FewArgs"))
+      assert(numFooArg.origin == Some("FewArgs"))
+    }
   }
 }


### PR DESCRIPTION
- Allow more custom argument parsers (via `Argument`), e.g. to parse options with a different shape than `--foo bar`
- Retain the class name where an option is defined, in `Arg.origin`
- Allow apps to accept a `--help-full` option, displaying hidden options and commands