### PR TITLE
Add Subproject for CE2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,9 @@ lazy val cats2 = crossProject(JSPlatform, JVMPlatform)
     },
     libraryDependencies ++= Seq(
       Deps.catsEffect2.value
-    )
+    ),
+    libraryDependencies += Deps.utest.value % Test,
+    testFrameworks += new TestFramework("utest.runner.Framework")
   )
 
 lazy val cats2JVM = cats2.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val cats2 = crossProject(JSPlatform, JVMPlatform)
   .settings(
     shared,
     name := "case-app-cats-effect-2",
-    Compile / scalaSource := file((catsJVM / Compile / scalaSource).value.toString.replace("jvm", "shared")),
+    Compile / sources := (catsJVM / Compile / sources).value,
     mimaPreviousArtifacts := {
       mimaPreviousArtifacts.value.filter(_.revision != "2.0.0")
     },

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val cats = crossProject(JSPlatform, JVMPlatform)
       mimaPreviousArtifacts.value.filter(_.revision != "2.0.0")
     },
     libraryDependencies ++= Seq(
-      Deps.catsEffect.value
+      Deps.catsEffect3.value
     ),
     libraryDependencies += Deps.utest.value % Test,
     testFrameworks += new TestFramework("utest.runner.Framework")
@@ -67,6 +67,25 @@ lazy val cats = crossProject(JSPlatform, JVMPlatform)
 
 lazy val catsJVM = cats.jvm
 lazy val catsJS = cats.js
+
+lazy val cats2 = crossProject(JSPlatform, JVMPlatform)
+  .dependsOn(core)
+  .jvmSettings(Mima.settings)
+  .jsSettings(Mima.settings)
+  .settings(
+    shared,
+    name := "case-app-cats-effect-2",
+    Compile / scalaSource := file((catsJVM / Compile / scalaSource).value.toString.replace("jvm", "shared")),
+    mimaPreviousArtifacts := {
+      mimaPreviousArtifacts.value.filter(_.revision != "2.0.0")
+    },
+    libraryDependencies ++= Seq(
+      Deps.catsEffect2.value
+    )
+  )
+
+lazy val cats2JVM = cats2.jvm
+lazy val cats2JS = cats2.js
 
 lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .nativeConfigure(_.disablePlugins(MimaPlugin))

--- a/cats2/shared/src/test/scala/caseapp/cats/CatsTests.scala
+++ b/cats2/shared/src/test/scala/caseapp/cats/CatsTests.scala
@@ -1,0 +1,113 @@
+package caseapp.cats
+
+import _root_.cats.effect._
+import _root_.cats.effect.concurrent.Ref
+import _root_.cats.implicits._
+import _root_.cats.data.NonEmptyList
+import caseapp._
+import caseapp.core.help.{CommandsHelp, Help}
+import caseapp.core.Error
+import utest._
+
+import caseapp.cats.CatsArgParser._
+
+sealed trait RecordedApp {
+
+  val stdoutBuff: Ref[IO, List[String]] = Ref.unsafe(List.empty)
+  val stderrBuff: Ref[IO, List[String]] = Ref.unsafe(List.empty)
+
+  def run(args: List[String]): IO[ExitCode]
+}
+
+private class RecordedIOCaseApp[T](implicit parser0: Parser[T], messages: Help[T]) extends IOCaseApp[T]()(parser0, messages) with RecordedApp {
+
+  override def error(message: Error): IO[ExitCode] =
+    stderrBuff.update(message.message :: _)
+      .as(ExitCode.Error)
+
+  override def println(x: String): IO[Unit] =
+    stdoutBuff.update(x :: _)
+
+  override def run(options: T, remainingArgs: RemainingArgs): IO[ExitCode] =
+    println(s"run: $options").as(ExitCode.Success)
+}
+
+private class RecordedIOCommandApp[T](implicit parser0: CommandParser[T], messages: CommandsHelp[T]) extends IOCommandApp[T]()(parser0, messages) with RecordedApp {
+
+  override def error(message: Error): IO[ExitCode] =
+    stderrBuff.update(message.message :: _)
+      .as(ExitCode.Error)
+
+  override def println(x: String): IO[Unit] =
+    stdoutBuff.update(x :: _)
+
+  override def run(options: T, remainingArgs: RemainingArgs): IO[ExitCode] =
+    println(s"run: $options").as(ExitCode.Success)
+}
+
+object CatsTests extends TestSuite {
+
+  import Definitions._
+
+  private def testCaseStdout(args: List[String], expected: String) =
+    testRunFuture(new RecordedIOCaseApp[FewArgs](), args, expectedStdout = List(expected), expectedStderr = List.empty)
+
+  private def testCaseStderr(args: List[String], expected: String) =
+    testRunFuture(new RecordedIOCaseApp[FewArgs](), args, expectedStdout = List.empty, expectedStderr = List(expected))
+
+  private def testCommandStdout(args: List[String], expected: String) =
+    testRunFuture(new RecordedIOCommandApp[Command](), args, expectedStdout = List(expected), expectedStderr = List.empty)
+
+  private def testCommandStderr(args: List[String], expected: String) =
+    testRunFuture(new RecordedIOCommandApp[Command](), args, expectedStdout = List.empty, expectedStderr = List(expected))
+
+  private def testRunFuture(app: RecordedApp, args: List[String], expectedStdout: List[String], expectedStderr: List[String]) = {
+    app.run(args)
+      .flatMap { _ =>
+        for {
+          stdoutRes <- app.stdoutBuff.get
+          stderrRes <- app.stderrBuff.get
+        } yield assert(stdoutRes == expectedStdout, stderrRes == expectedStderr)
+      }
+      .unsafeToFuture()
+  }
+
+  override def tests: Tests = Tests {
+    test("IOCaseApp") {
+      test("output usage") {
+        testCaseStdout(List("--usage"), Help[FewArgs].withHelp.usage)
+      }
+      test("output help") {
+        testCaseStdout(List("--help"), Help[FewArgs].withHelp.help)
+      }
+      test("parse error") {
+        testCaseStderr(List("--invalid"), "Unrecognized argument: --invalid")
+      }
+      test("run") {
+        testCaseStdout(List("--value", "foo", "--num-foo", "42"), "run: FewArgs(foo,42)")
+      }
+    }
+    test("IOCommandApp") {
+      test("parse error") {
+        testCommandStderr(List("--invalid"), "Unrecognized argument: --invalid")
+      }
+      test("output command usage") {
+        testCommandStdout(List("first", "--usage"), CommandsHelp[Command].messagesMap(List("first")).usageMessage("none.type", List("first")))
+      }
+      test("output command help") {
+        testCommandStdout(List("first", "--help"), CommandsHelp[Command].messagesMap(List("first")).helpMessage("none.type", List("first")))
+      }
+      test("run") {
+        testCommandStdout(List("first", "--foo", "foo", "--bar", "42"), "run: First(foo,42)")
+      }
+    }
+
+    test("parse nonEmptyList args") {
+      val res =
+        Parser[WithNonEmptyList].parse(Seq("--nel", "2", "--nel", "5", "extra"))
+      val expectedRes =
+        Right((WithNonEmptyList(nel = NonEmptyList.of("2", "5")), Seq("extra")))
+      assert(res == expectedRes)
+    }
+  }
+}

--- a/cats2/shared/src/test/scala/caseapp/cats/Definitions.scala
+++ b/cats2/shared/src/test/scala/caseapp/cats/Definitions.scala
@@ -1,0 +1,37 @@
+package caseapp
+package cats
+
+import _root_.cats.data.NonEmptyList
+
+object Definitions {
+
+  final case class FewArgs(
+    value  : String = "default",
+    numFoo : Int = -10
+  )
+
+  final case class WithNonEmptyList(nel: NonEmptyList[String])
+
+  sealed trait Command
+
+  case class First(
+    @ExtraName("f")
+      foo: String = "",
+    bar: Int = 0
+  ) extends Command
+
+  case class Second(
+    fooh: String = "",
+    baz: Int = 0
+  ) extends Command
+
+  @HelpMessage("Third help message")
+  case class Third(
+    third: Int = 0
+  ) extends Command
+
+  object CommandTest extends CommandApp[Command] {
+    def run(options: Command, remainingArgs: RemainingArgs): Unit = {}
+  }
+
+}

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,7 +8,8 @@ object Deps {
 
   import Def.setting
 
-  def catsEffect = setting("org.typelevel" %%% "cats-effect" % "3.2.0")
+  def catsEffect2 = setting("org.typelevel" %%% "cats-effect" % "2.5.1")
+  def catsEffect3 = setting("org.typelevel" %%% "cats-effect" % "3.2.0")
   def dataClass = "io.github.alexarchambault" %% "data-class" % "0.2.5"
   def macroParadise = "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch
   def refined = setting("eu.timepit" %%% "refined" % "0.9.27")


### PR DESCRIPTION
Hi!  This PR is in response to https://github.com/alexarchambault/case-app/pull/285#issuecomment-856258916, I was using the existing `2.0.6` release and came across the problem described in that thread when using `case-app` in tandem with `pureconfig` as that uses shapeless `2.3.7`.

As per the comment, the artifact name of the new module is `case-app-cats-effect-2` and it's essentially just an empty subproject with the compile src set the src of the existing cats module.  I've tested the new module using `publishLocal` and it appears to work fine.

Whilst the source is compatible with CE2 and CE3, the test source is not, so I've not set the test source dir to the cats test src dir in the new subproject for now, let me now if you have any issues with this.

I'm no sbt expert so apologies in advance if you find anything untoward :sweat_smile: 