### PR TITLE
Add support for filtering individual options in help output

### DIFF
--- a/core/shared/src/main/scala-3/caseapp/core/Scala3Helpers.scala
+++ b/core/shared/src/main/scala-3/caseapp/core/Scala3Helpers.scala
@@ -58,6 +58,9 @@ object Scala3Helpers {
       helpFormat.copy(sortedGroups = sortedGroups)
     def withHiddenGroups(hiddenGroups: Option[Seq[String]]): HelpFormat =
       helpFormat.copy(hiddenGroups = hiddenGroups)
+
+    def withFilterArgs(filterArgs: Option[Arg => Boolean]): HelpFormat =
+      helpFormat.copy(filterArgs = filterArgs)
   }
 
   implicit class OptionParserWithOps[T](private val parser: OptionParser[T]) {

--- a/core/shared/src/main/scala/caseapp/core/help/Help.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/Help.scala
@@ -135,7 +135,8 @@ import caseapp.HelpMessage
 
   def printOptions(b: StringBuilder, format: HelpFormat, showHidden: Boolean): Unit =
     if (args.nonEmpty) {
-      val groupedArgs  = args.groupBy(_.group.fold("")(_.name))
+      val filteredArgs = format.filterArgs.map(args.filter).getOrElse(args)
+      val groupedArgs  = filteredArgs.groupBy(_.group.fold("")(_.name))
       val groups       = format.sortGroupValues(groupedArgs.toVector)
       val sortedGroups = groups.filter(_._1.nonEmpty) ++ groupedArgs.get("").toSeq.map("" -> _)
       for {

--- a/core/shared/src/main/scala/caseapp/core/help/HelpFormat.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/HelpFormat.scala
@@ -1,5 +1,6 @@
 package caseapp.core.help
 
+import caseapp.core.Arg
 import caseapp.core.Scala3Helpers._
 import caseapp.core.util.fansi
 import dataclass._
@@ -15,7 +16,8 @@ import dataclass._
   sortCommandGroups: Option[Seq[String] => Seq[String]] = None,
   sortedCommandGroups: Option[Seq[String]] = None,
   hidden: fansi.Attrs = fansi.Attrs.Empty,
-  terminalWidthOpt: Option[Int] = None
+  terminalWidthOpt: Option[Int] = None,
+  @since filterArgs: Option[Arg => Boolean] = None
 ) {
   private def sortValues[T](
     sortGroups: Option[Seq[String] => Seq[String]],

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -8,7 +8,7 @@ import scala.sys.process._
 object Mima {
 
   def binaryCompatibilityVersions: Set[String] =
-    Seq("git", "tag", "--merged", "HEAD^", "--contains", "5a653bdd41972587bd3fb3d9751c0e0cf11c1e74")
+    Seq("git", "tag", "--merged", "HEAD^", "--contains", "1acab44cf68aeebb575bd1c920f96397519a18d0")
       .!!
       .linesIterator
       .map(_.trim)

--- a/tests/shared/src/test/scala/caseapp/HelpDefinitions.scala
+++ b/tests/shared/src/test/scala/caseapp/HelpDefinitions.scala
@@ -3,6 +3,7 @@ package caseapp
 object HelpDefinitions {
   case class FirstOptions(
     @ExtraName("f")
+    @Tag("foo")
     foo: String = "",
     bar: Int = 0
   )

--- a/tests/shared/src/test/scala/caseapp/HelpTests.scala
+++ b/tests/shared/src/test/scala/caseapp/HelpTests.scala
@@ -1,5 +1,6 @@
 package caseapp
 
+import caseapp.core.Arg
 import caseapp.core.app.CommandsEntryPoint
 import caseapp.core.help.{Help, HelpFormat, RuntimeCommandHelp, RuntimeCommandsHelp}
 import caseapp.core.Scala3Helpers._
@@ -393,6 +394,36 @@ object HelpTests extends TestSuite {
           |Other options:
           |  -f, --foo string
           |  --bar int
+          |
+          |Bb commands:
+          |  second""".stripMargin
+
+      assert(help == expected)
+    }
+    test("help message with filtered args") {
+      val entryPoint: CommandsEntryPoint = new CommandsEntryPoint {
+        def progName = "foo"
+
+        override def defaultCommand = Some(CommandGroups.First)
+
+        def commands = Seq(CommandGroups.First, CommandGroups.Second, CommandGroups.Third)
+      }
+      val filterArgsFunction    = (a: Arg) => !a.tags.exists(_.name == "foo")
+      val formatWithHiddenGroup = format.withFilterArgs(Some(filterArgsFunction))
+      val help                  = entryPoint.help.help(formatWithHiddenGroup)
+      val expected =
+        """Usage: foo <COMMAND> [options]
+          |
+          |Help options:
+          |  --usage            Print usage and exit
+          |  -h, -help, --help  Print help message and exit
+          |
+          |Other options:
+          |  --bar int
+          |
+          |Aa commands:
+          |  first
+          |  third  Third help message
           |
           |Bb commands:
           |  second""".stripMargin


### PR DESCRIPTION
necessary to filter out options tagged as `restricted` or `experimental` in individual sub-commands help in Scala CLI relevant ticket: https://github.com/VirtusLab/scala-cli/issues/1669