### PR TITLE
Add parameter to HelpFormat for reducing number of names displayed

### DIFF
--- a/core/shared/src/main/scala-3/caseapp/core/Scala3Helpers.scala
+++ b/core/shared/src/main/scala-3/caseapp/core/Scala3Helpers.scala
@@ -67,6 +67,9 @@ object Scala3Helpers {
 
     def withHiddenGroupsWhenShowHidden(hiddenGroups: Option[Seq[String]]): HelpFormat =
       helpFormat.copy(hiddenGroupsWhenShowHidden = hiddenGroups)
+
+    def withNamesLimit(newNamesLimit: Option[Int]): HelpFormat =
+      helpFormat.copy(namesLimit = newNamesLimit)
   }
 
   implicit class OptionParserWithOps[T](private val parser: OptionParser[T]) {

--- a/core/shared/src/main/scala-3/caseapp/core/parser/LowPriorityParserImplicits.scala
+++ b/core/shared/src/main/scala-3/caseapp/core/parser/LowPriorityParserImplicits.scala
@@ -115,7 +115,7 @@ object LowPriorityParserImplicits {
             .collect {
               case Apply(_, List(arg)) =>
                 '{ caseapp.ExtraName(${ arg.asExprOf[String] }) }
-            }
+            }.reverse
           val valueDescription = sym.annotations
             .find(_.tpe =:= TypeRepr.of[caseapp.ValueDescription])
             .collect {

--- a/core/shared/src/main/scala/caseapp/core/help/Help.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/Help.scala
@@ -227,7 +227,13 @@ object Help extends HelpCompanion {
     showHidden: Boolean
   ): Seq[Seq[fansi.Str]] =
     for (arg <- args if showHidden || !arg.noHelp) yield {
-      val sortedNames = (arg.name +: arg.extraNames)
+      val namesToShow = format.namesLimit match {
+        case Some(limit) if !showHidden && limit >= 0 =>
+          (arg.name +: arg.extraNames).take(limit)
+        case _ => arg.name +: arg.extraNames
+      }
+
+      val sortedNames = namesToShow
         .map(name => format.option(name.option(nameFormatter)))
         .groupBy(_.length)
         .toVector

--- a/core/shared/src/main/scala/caseapp/core/help/HelpFormat.scala
+++ b/core/shared/src/main/scala/caseapp/core/help/HelpFormat.scala
@@ -19,7 +19,9 @@ import dataclass._
   terminalWidthOpt: Option[Int] = None,
   @since filterArgs: Option[Arg => Boolean] = None,
   @since filterArgsWhenShowHidden: Option[Arg => Boolean] = None,
-  hiddenGroupsWhenShowHidden: Option[Seq[String]] = None
+  hiddenGroupsWhenShowHidden: Option[Seq[String]] = None,
+  @since("2.1.0-M25")
+  namesLimit: Option[Int] = None
 ) {
   private def sortValues[T](
     sortGroups: Option[Seq[String] => Seq[String]],

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -8,7 +8,7 @@ import scala.sys.process._
 object Mima {
 
   def binaryCompatibilityVersions: Set[String] =
-    Seq("git", "tag", "--merged", "HEAD^", "--contains", "d83b49829681f550c39e31b4c526dffd8c6dba89")
+    Seq("git", "tag", "--merged", "HEAD^", "--contains", "8e0544e5ce1f9ce1dd3bd85308332b5dd1cd4985")
       .!!
       .linesIterator
       .map(_.trim)

--- a/tests/shared/src/test/scala/caseapp/HelpDefinitions.scala
+++ b/tests/shared/src/test/scala/caseapp/HelpDefinitions.scala
@@ -18,6 +18,15 @@ object HelpDefinitions {
     third: Int = 0
   )
 
+  case class FourthOptions(
+    @ExtraName("fourOption")
+    @ExtraName("f")
+    @ExtraName("four")
+    @ExtraName("fOpt")
+
+    fourth: Int = 0
+  )
+
   object First extends Command[FirstOptions] {
     def run(options: FirstOptions, args: RemainingArgs) = ???
   }
@@ -26,6 +35,10 @@ object HelpDefinitions {
   }
   object Third extends Command[ThirdOptions] {
     def run(options: ThirdOptions, args: RemainingArgs) = ???
+  }
+
+  object Fourth extends Command[FourthOptions] {
+    def run(options: FourthOptions, args: RemainingArgs) = ???
   }
 
   @HelpMessage("Example help message")


### PR DESCRIPTION
Connected to https://github.com/VirtusLab/scala-cli/issues/1883

Using the `namesLimit = Some(N)` parameter in HelpFormat would pick N-1 first name aliases + the main name.
For example, for option:
```
    @ExtraName("fourOption")
    @ExtraName("f")
    @ExtraName("four")
    @ExtraName("fOpt")
    fourth: Int = 0
```

and `namesLimit = Some(2)` will result in `--fourth, --four-option` getting displayed
and for full help `-f, --four, --f-opt, --fourth, --four-option`

@alexarchambault could You take a look at this?