### PR TITLE
Add a wrapper to the gpg command used by sbt ci-release

### DIFF
--- a/.github/scripts/wrap-gpg.sh
+++ b/.github/scripts/wrap-gpg.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+mkdir -p ~/mybin
+touch ~/mybin/gpg
+chmod +x ~/mybin/gpg
+echo '#!/usr/bin/env sh' > ~/mybin/gpg
+echo "$(which gpg) --no-tty --yes \"\$@\"" >> ~/mybin/gpg
+echo "$HOME/mybin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
     - run: .github/scripts/gpg-setup.sh
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
+    - name: Wrap GPG binary
+      run: .github/scripts/wrap-gpg.sh
     - name: Release
       run: sbtn ci-release
       env:


### PR DESCRIPTION
Trying to fix the [failing publish CI](https://github.com/alexarchambault/case-app/actions/runs/5319876605)
by adding options `--no-tty --yes` to the gpg command using a 'wrapper' script