### PR TITLE
Revert "Add an optional prefix for Recurse (#483)"

### DIFF
--- a/annotations/shared/src/main/scala/caseapp/Annotations.scala
+++ b/annotations/shared/src/main/scala/caseapp/Annotations.scala
@@ -44,17 +44,8 @@ final case class AppVersion(appVersion: String) extends StaticAnnotation
 final case class ArgsName(argsName: String) extends StaticAnnotation
 
 /** Don't parse the annotated field as a single argument. Recurse on its fields instead.
-  *
-  * Optionally, add a prefix to all the names of the fields.
   */
-final case class Recurse(prefix: String) extends StaticAnnotation {
-  def this() = this("")
-}
-
-object Recurse {
-  def apply(): Recurse =
-    new Recurse
-}
+final class Recurse extends StaticAnnotation
 
 /** Do not include this field / argument in the help message
   */

--- a/annotations/shared/src/main/scala/caseapp/Annotations.scala
+++ b/annotations/shared/src/main/scala/caseapp/Annotations.scala
@@ -44,8 +44,17 @@ final case class AppVersion(appVersion: String) extends StaticAnnotation
 final case class ArgsName(argsName: String) extends StaticAnnotation
 
 /** Don't parse the annotated field as a single argument. Recurse on its fields instead.
+  *
+  * Optionally, add a prefix to all the names of the fields.
   */
-final class Recurse extends StaticAnnotation
+final case class Recurse(prefix: String) extends StaticAnnotation {
+  def this() = this("")
+}
+
+object Recurse {
+  def apply(): Recurse =
+    new Recurse
+}
 
 /** Do not include this field / argument in the help message
   */

--- a/build.sc
+++ b/build.sc
@@ -360,7 +360,7 @@ trait MimaChecks extends Mima {
       "--merged",
       "HEAD^",
       "--contains",
-      "27cdd86548d413c656b9493e625523b1e642c9be"
+      "993ac3020db84ba06231e0268c920c9f8b9f3520"
     )
       .call()
       .out.lines()

--- a/core/shared/src/main/scala-2/caseapp/core/help/WithFullHelpCompanion.scala
+++ b/core/shared/src/main/scala-2/caseapp/core/help/WithFullHelpCompanion.scala
@@ -1,6 +1,6 @@
 package caseapp.core.help
 
-import caseapp.{ExtraName, Group, HelpMessage, Parser, Recurse}
+import caseapp.{ExtraName, Group, HelpMessage, Parser}
 import caseapp.core.parser.{Argument, NilParser, StandardArgument}
 import caseapp.core.{Arg, Error}
 import caseapp.core.parser.RecursiveConsParser
@@ -55,7 +55,7 @@ abstract class WithFullHelpCompanion {
 
     val withHelpParser = WithHelp.parser[T, D](underlying)
 
-    val p = RecursiveConsParser(withHelpParser, helpArgument :: NilParser, Recurse())
+    val p = RecursiveConsParser(withHelpParser, helpArgument :: NilParser)
 
     p.to[WithFullHelp[T]]
   }

--- a/core/shared/src/main/scala-2/caseapp/core/help/WithHelpCompanion.scala
+++ b/core/shared/src/main/scala-2/caseapp/core/help/WithHelpCompanion.scala
@@ -1,6 +1,6 @@
 package caseapp.core.help
 
-import caseapp.{ExtraName, Group, HelpMessage, Parser, Recurse}
+import caseapp.{ExtraName, Group, Help, HelpMessage, Parser}
 import caseapp.core.parser.{Argument, NilParser, StandardArgument}
 import caseapp.core.{Arg, Error}
 import caseapp.core.parser.{EitherParser, RecursiveConsParser}
@@ -56,7 +56,7 @@ abstract class WithHelpCompanion {
 
     val p = usageArgument ::
       helpArgument ::
-      RecursiveConsParser(either, NilParser, Recurse())
+      RecursiveConsParser(either, NilParser)
 
     p.to[WithHelp[T]]
   }

--- a/core/shared/src/main/scala-2/caseapp/core/parser/HListParserBuilder.scala
+++ b/core/shared/src/main/scala-2/caseapp/core/parser/HListParserBuilder.scala
@@ -16,7 +16,7 @@ sealed abstract class HListParserBuilder[
   -G <: HList,
   -H <: HList,
   -T <: HList,
-  -R <: HList
+  R <: HList
 ] {
   type P <: HList
   def apply(
@@ -26,8 +26,7 @@ sealed abstract class HListParserBuilder[
     helpMessages: M,
     groups: G,
     noHelp: H,
-    tags: T,
-    recurse: R
+    tags: T
   ): Parser.Aux[L, P]
 }
 
@@ -74,7 +73,7 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
     R <: HList,
     P0 <: HList
   ](
-    p: (() => D, N, V, M, G, H, T, R) => Parser.Aux[L, P0]
+    p: (() => D, N, V, M, G, H, T) => Parser.Aux[L, P0]
   ): Aux[L, D, N, V, M, G, H, T, R, P0] =
     new HListParserBuilder[L, D, N, V, M, G, H, T, R] {
       type P = P0
@@ -85,14 +84,13 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
         helpMessages: M,
         group: G,
         noHelp: H,
-        tags: T,
-        recurse: R
+        tags: T
       ) =
-        p(() => default, names, valueDescriptions, helpMessages, group, noHelp, tags, recurse)
+        p(() => default, names, valueDescriptions, helpMessages, group, noHelp, tags)
     }
 
   implicit val hnil: Aux[HNil, HNil, HNil, HNil, HNil, HNil, HNil, HNil, HNil, HNil] =
-    instance { (_, _, _, _, _, _, _, _) =>
+    instance { (_, _, _, _, _, _, _) =>
       NilParser
     }
 
@@ -126,7 +124,7 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
     None.type :: RT,
     Option[H] :: PT
   ] =
-    instance { (default0, names, valueDescriptions, helpMessages, groups, noHelp, tags, recurse) =>
+    instance { (default0, names, valueDescriptions, helpMessages, groups, noHelp, tags) =>
 
       val tailParser = tail.value(
         default0().tail,
@@ -135,8 +133,7 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
         helpMessages.tail,
         groups.tail,
         noHelp.tail,
-        tags.tail,
-        recurse.tail
+        tags.tail
       )
 
       val arg = Arg(
@@ -184,7 +181,7 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
     Some[Recurse] :: RT,
     headParser.value.D :: PT
   ] =
-    instance { (default0, names, valueDescriptions, helpMessages, groups, noHelp, tags, recurse) =>
+    instance { (default0, names, valueDescriptions, helpMessages, groups, noHelp, tags) =>
 
       val tailParser = tail(
         default0().tail,
@@ -193,11 +190,10 @@ object HListParserBuilder extends LowPriorityHListParserBuilder {
         helpMessages.tail,
         groups.tail,
         noHelp.tail,
-        tags.tail,
-        recurse.tail
+        tags.tail
       )
 
-      RecursiveConsParser(headParser.value, tailParser, recurse.head.value)
+      RecursiveConsParser(headParser.value, tailParser)
         .mapHead(field[K](_))
     }
 }

--- a/core/shared/src/main/scala-2/caseapp/core/parser/LowPriorityHListParserBuilder.scala
+++ b/core/shared/src/main/scala-2/caseapp/core/parser/LowPriorityHListParserBuilder.scala
@@ -38,7 +38,7 @@ abstract class LowPriorityHListParserBuilder {
     None.type :: RT,
     Option[H] :: PT
   ] =
-    instance { (default0, names, valueDescriptions, helpMessages, groups, noHelp, tags, recurse) =>
+    instance { (default0, names, valueDescriptions, helpMessages, groups, noHelp, tags) =>
 
       val tailParser = tail.value(
         default0().tail,
@@ -47,8 +47,7 @@ abstract class LowPriorityHListParserBuilder {
         helpMessages.tail,
         groups.tail,
         noHelp.tail,
-        tags.tail,
-        recurse.tail
+        tags.tail
       )
 
       val arg = Arg(

--- a/core/shared/src/main/scala-2/caseapp/core/parser/LowPriorityParserImplicits.scala
+++ b/core/shared/src/main/scala-2/caseapp/core/parser/LowPriorityParserImplicits.scala
@@ -40,8 +40,7 @@ trait LowPriorityParserImplicits {
         helpMessages(),
         group(),
         noHelp(),
-        tags(),
-        recurse()
+        tags()
       )
       .map(gen.from)
       .withDefaultOrigin(typeable.describe)

--- a/core/shared/src/main/scala-2/caseapp/core/parser/ParserOps.scala
+++ b/core/shared/src/main/scala-2/caseapp/core/parser/ParserOps.scala
@@ -1,6 +1,6 @@
 package caseapp.core.parser
 
-import caseapp.{HelpMessage, Name, Recurse, ValueDescription}
+import caseapp.{HelpMessage, Name, ValueDescription}
 import caseapp.core.argparser.ArgParser
 import caseapp.core.Arg
 import shapeless.{::, Generic, HList, ops}
@@ -55,7 +55,7 @@ object ParserOps {
 
   class AddAllHelper[T <: HList, D <: HList, U](val parser: Parser.Aux[T, D]) extends AnyVal {
     def apply[DU](implicit other: Parser.Aux[U, DU]): Parser.Aux[U :: T, DU :: D] =
-      RecursiveConsParser(other, parser, Recurse())
+      RecursiveConsParser(other, parser)
   }
 
   sealed abstract class AsHelper[T, F] {

--- a/core/shared/src/main/scala-2/caseapp/core/parser/RecursiveConsParser.scala
+++ b/core/shared/src/main/scala-2/caseapp/core/parser/RecursiveConsParser.scala
@@ -1,6 +1,6 @@
 package caseapp.core.parser
 
-import caseapp.{Name, Recurse}
+import caseapp.Name
 import caseapp.core.{Arg, Error}
 import caseapp.core.util.Formatter
 import shapeless.{::, HList}
@@ -8,8 +8,7 @@ import dataclass.data
 
 @data class RecursiveConsParser[H, HD, T <: HList, TD <: HList](
   headParser: Parser.Aux[H, HD],
-  tailParser: Parser.Aux[T, TD],
-  recurse: Recurse
+  tailParser: Parser.Aux[T, TD]
 ) extends Parser[H :: T] {
 
   type D = HD :: TD
@@ -24,7 +23,7 @@ import dataclass.data
     nameFormatter: Formatter[Name]
   ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
     headParser
-      .step(args, index, d.head, Formatter.addRecursePrefix(recurse, nameFormatter))
+      .step(args, index, d.head, nameFormatter)
       .flatMap {
         case None =>
           tailParser

--- a/core/shared/src/main/scala-3/caseapp/core/help/WithFullHelpCompanion.scala
+++ b/core/shared/src/main/scala-3/caseapp/core/help/WithFullHelpCompanion.scala
@@ -1,6 +1,6 @@
 package caseapp.core.help
 
-import caseapp.{ExtraName, Group, HelpMessage, Parser, Recurse}
+import caseapp.{ExtraName, Group, HelpMessage, Parser}
 import caseapp.core.Scala3Helpers.*
 import caseapp.core.parser.{Argument, NilParser, StandardArgument}
 import caseapp.core.{Arg, Error}
@@ -51,7 +51,7 @@ abstract class WithFullHelpCompanion {
 
     val withHelpParser = WithHelp.parser[T](underlying)
 
-    val p = RecursiveConsParser(withHelpParser, helpArgument :: NilParser, Recurse())
+    val p = RecursiveConsParser(withHelpParser, helpArgument :: NilParser)
 
     p.to[WithFullHelp[T]]
   }

--- a/core/shared/src/main/scala-3/caseapp/core/help/WithHelpCompanion.scala
+++ b/core/shared/src/main/scala-3/caseapp/core/help/WithHelpCompanion.scala
@@ -1,6 +1,6 @@
 package caseapp.core.help
 
-import caseapp.{ExtraName, Group, Help, HelpMessage, Parser, Recurse}
+import caseapp.{ExtraName, Group, Help, HelpMessage, Parser}
 import caseapp.core.Scala3Helpers.*
 import caseapp.core.parser.{Argument, NilParser, StandardArgument}
 import caseapp.core.{Arg, Error}
@@ -55,7 +55,7 @@ abstract class WithHelpCompanion {
 
     val p = usageArgument ::
       helpArgument ::
-      RecursiveConsParser(either, NilParser, Recurse())
+      RecursiveConsParser(either, NilParser)
 
     p.to[WithHelp[T]]
   }

--- a/core/shared/src/main/scala-3/caseapp/core/parser/ParserOps.scala
+++ b/core/shared/src/main/scala-3/caseapp/core/parser/ParserOps.scala
@@ -1,6 +1,6 @@
 package caseapp.core.parser
 
-import caseapp.{HelpMessage, Name, Recurse, ValueDescription}
+import caseapp.{HelpMessage, Name, ValueDescription}
 import caseapp.core.argparser.ArgParser
 import caseapp.core.Arg
 import caseapp.core.util.Formatter
@@ -35,7 +35,7 @@ class ParserOps[T <: Tuple](val parser: Parser[T]) extends AnyVal {
   }
 
   def addAll[H](using headParser: Parser[H]): Parser[H *: T] =
-    RecursiveConsParser(headParser, parser, Recurse())
+    RecursiveConsParser(headParser, parser)
 
   def as[F](using
     m: Mirror.ProductOf[F],

--- a/core/shared/src/main/scala-3/caseapp/core/parser/RecursiveConsParser.scala
+++ b/core/shared/src/main/scala-3/caseapp/core/parser/RecursiveConsParser.scala
@@ -1,6 +1,6 @@
 package caseapp.core.parser
 
-import caseapp.{Name, Recurse}
+import caseapp.Name
 import caseapp.core.{Arg, Error}
 import caseapp.core.util.Formatter
 import caseapp.core.Scala3Helpers._
@@ -8,8 +8,7 @@ import dataclass.data
 
 case class RecursiveConsParser[H, T <: Tuple](
   headParser: Parser[H],
-  tailParser: Parser[T],
-  recurse: Recurse
+  tailParser: Parser[T]
 ) extends Parser[H *: T] {
 
   type D = headParser.D *: tailParser.D
@@ -24,12 +23,7 @@ case class RecursiveConsParser[H, T <: Tuple](
     nameFormatter: Formatter[Name]
   ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
     headParser
-      .step(
-        args,
-        index,
-        runtime.Tuples(d, 0).asInstanceOf[headParser.D],
-        Formatter.addRecursePrefix(recurse, nameFormatter)
-      )
+      .step(args, index, runtime.Tuples(d, 0).asInstanceOf[headParser.D], nameFormatter)
       .flatMap {
         case None =>
           tailParser

--- a/core/shared/src/main/scala/caseapp/core/util/Formatter.scala
+++ b/core/shared/src/main/scala/caseapp/core/util/Formatter.scala
@@ -1,6 +1,6 @@
 package caseapp.core.util
 
-import caseapp.{Name, Recurse}
+import caseapp.Name
 
 abstract class Formatter[T] {
   def format(t: T): String
@@ -21,18 +21,4 @@ object Formatter {
         .map(_.toLowerCase)
         .mkString("-")
   }
-
-  /** Adds the prefix for the Recurse annotation to the names formatted by the formatter.
-    *
-    * Adds the prefix as `prefix-foo-bar`.
-    */
-  def addRecursePrefix(recurse: Recurse, formatter: Formatter[Name]): Formatter[Name] =
-    if (recurse.prefix.isEmpty()) formatter
-    else
-      new Formatter[Name] {
-        def format(t: Name): String = {
-          val formattedPrefix = formatter.format(Name(recurse.prefix))
-          s"$formattedPrefix-${formatter.format(t)}"
-        }
-      }
 }

--- a/tests/shared/src/test/scala/caseapp/CaseAppTests.scala
+++ b/tests/shared/src/test/scala/caseapp/CaseAppTests.scala
@@ -112,22 +112,6 @@ object CaseAppTests extends TestSuite {
       assert(res == expectedRes)
     }
 
-    test("parse a args recursively with a prefix added") {
-      val res = Parser[RecurseWithPrefix].parse(Seq(
-        "--no-prefix",
-        "4",
-        "--prefix-value",
-        "value",
-        "--prefix-num-foo",
-        "10"
-      ))
-      val expectedRes = Right((
-        RecurseWithPrefix(noPrefix = 4, withPrefix = FewArgs(value = "value", numFoo = 10)),
-        Seq.empty
-      ))
-      assert(res == expectedRes)
-    }
-
     test("parse args") {
       val res = Parser[demo.DemoOptions].parse(Seq(
         "user arg",

--- a/tests/shared/src/test/scala/caseapp/Definitions.scala
+++ b/tests/shared/src/test/scala/caseapp/Definitions.scala
@@ -178,8 +178,4 @@ object Definitions {
     elem: List[Indexed[String]] = Nil
   )
 
-  final case class RecurseWithPrefix(
-    noPrefix: Int,
-    @Recurse("prefix") withPrefix: FewArgs
-  )
 }


### PR DESCRIPTION
This reverts the addition of `prefix` for recurse. A few issues were found:

1. a `Recurse` with prefix of a case class that also contained a `Recurse` with prefix had the incorrect arg name
2. help did not incorporate the prefix
3. Mystery failure https://github.com/VirtusLab/scala-cli/pull/2964