### PR TITLE
Add IOCommand and IOCommandsEntryPoint to cats module

### DIFF
--- a/cats/shared/src/main/scala/caseapp/catseffect/IOCommand.scala
+++ b/cats/shared/src/main/scala/caseapp/catseffect/IOCommand.scala
@@ -1,0 +1,123 @@
+package caseapp.catseffect
+
+import caseapp.core.Error
+import caseapp.core.RemainingArgs
+import caseapp.core.Scala3Helpers._
+import caseapp.core.help.{Help, HelpFormat, WithHelp}
+import caseapp.core.parser.Parser
+import caseapp.Name
+import caseapp.core.util.Formatter
+import caseapp.core.complete.{Completer, CompletionItem, HelpCompleter}
+import cats.effect.{ExitCode, IO}
+
+abstract class IOCommand[T](implicit val parser0: Parser[T], val messages: Help[T]) {
+
+  def names: List[List[String]] =
+    List(List(name))
+  def group: String   = ""
+  def hidden: Boolean = false
+
+  def name: String =
+    messages.progName
+
+  def hasHelp: Boolean     = true
+  def hasFullHelp: Boolean = false
+
+  def help: Help[T] = messages
+
+  def parser: Parser[T] = {
+    val p = parser0.nameFormatter(nameFormatter)
+    if (ignoreUnrecognized)
+      p.ignoreUnrecognized
+    else if (stopAtFirstUnrecognized)
+      p.stopAtFirstUnrecognized
+    else
+      p
+  }
+
+  def completer: Completer[T] =
+    new HelpCompleter[T](messages)
+
+  def complete(args: Seq[String], index: Int): List[CompletionItem] =
+    if (hasFullHelp)
+      parser.withFullHelp.complete(
+        args,
+        index,
+        completer.withFullHelp,
+        stopAtFirstUnrecognized,
+        ignoreUnrecognized
+      )
+    else if (hasHelp)
+      parser.withHelp.complete(
+        args,
+        index,
+        completer.withHelp,
+        stopAtFirstUnrecognized,
+        ignoreUnrecognized
+      )
+    else
+      parser.complete(
+        args,
+        index,
+        completer,
+        stopAtFirstUnrecognized,
+        ignoreUnrecognized
+      )
+
+  def run(options: T, remainingArgs: RemainingArgs): IO[ExitCode]
+
+  def error(message: Error): IO[ExitCode] =
+    IO(Console.err.println(message.message))
+      .as(ExitCode.Error)
+
+  def helpAsked(progName: String): IO[ExitCode] = {
+    val h =
+      if (progName.isEmpty) finalHelp
+      else finalHelp.withProgName(progName)
+    println(h.help(helpFormat, showHidden = false))
+      .as(ExitCode.Success)
+  }
+
+  def usageAsked(progName: String): IO[ExitCode] = {
+    val h =
+      if (progName.isEmpty) finalHelp
+      else finalHelp.withProgName(progName)
+    println(h.usage(helpFormat))
+      .as(ExitCode.Success)
+  }
+
+  def println(x: String): IO[Unit] =
+    IO(Console.println(x))
+
+  lazy val finalHelp: Help[_] =
+    if (hasFullHelp) messages.withFullHelp
+    else if (hasHelp) messages.withHelp
+    else messages
+
+  def helpFormat: HelpFormat =
+    HelpFormat.default()
+
+  def expandArgs(args: List[String]): List[String] = args
+
+  def stopAtFirstUnrecognized: Boolean =
+    false
+
+  def ignoreUnrecognized: Boolean =
+    false
+
+  def nameFormatter: Formatter[Name] =
+    Formatter.DefaultNameFormatter
+
+  def main(progName: String, args: Array[String]): IO[ExitCode] =
+    parser.withHelp.detailedParse(
+      expandArgs(args.toList),
+      stopAtFirstUnrecognized,
+      ignoreUnrecognized
+    ) match {
+      case Left(err)                                        => error(err)
+      case Right((WithHelp(_, true, _), _))                 => helpAsked(progName)
+      case Right((WithHelp(true, _, _), _))                 => usageAsked(progName)
+      case Right((WithHelp(_, _, Left(err)), _))            => error(err)
+      case Right((WithHelp(_, _, Right(t)), remainingArgs)) => run(t, remainingArgs)
+    }
+}

--- a/cats/shared/src/main/scala/caseapp/catseffect/IOCommandsEntryPoint.scala
+++ b/cats/shared/src/main/scala/caseapp/catseffect/IOCommandsEntryPoint.scala
@@ -1,0 +1,58 @@
+package caseapp.catseffect
+
+import caseapp.core.commandparser.RuntimeCommandParser
+import caseapp.core.help.{Help, HelpFormat, RuntimeCommandHelp, RuntimeCommandsHelp}
+import cats.effect.{ExitCode, IO, IOApp}
+
+abstract class IOCommandsEntryPoint extends IOApp {
+
+  def defaultCommand: Option[IOCommand[_]] = None
+  def commands: Seq[IOCommand[_]]
+
+  def progName: String
+  def description: String = ""
+  def summaryDesc: String = ""
+
+  def help: RuntimeCommandsHelp =
+    RuntimeCommandsHelp(
+      progName,
+      Some(description).filter(_.nonEmpty),
+      defaultCommand.map(_.finalHelp: Help[_]).getOrElse(Help[Unit]()),
+      commands.map(cmd => RuntimeCommandHelp(cmd.names, cmd.finalHelp, cmd.group, cmd.hidden)),
+      Some(summaryDesc).filter(_.nonEmpty)
+    )
+
+  def helpFormat: HelpFormat =
+    HelpFormat.default()
+
+  private def commandProgName(commandName: List[String]): String =
+    (progName +: commandName).mkString(" ")
+
+  private def commandMap: Map[List[String], IOCommand[_]] =
+    commands.flatMap(cmd =>
+      cmd.names.map(names => names -> cmd)
+    ).toMap
+
+  def printUsage(): IO[ExitCode] = {
+    val usage = help.help(helpFormat, showHidden = false)
+    IO(Console.println(usage)).as(ExitCode.Success)
+  }
+
+  override def run(args: List[String]): IO[ExitCode] = {
+    val map = commandMap
+    defaultCommand match {
+      case None =>
+        RuntimeCommandParser.parse(map, args) match {
+          case None =>
+            printUsage()
+          case Some((commandName, command, commandArgs)) =>
+            command.main(commandProgName(commandName), commandArgs.toArray)
+        }
+      case Some(defaultCommand0) =>
+        RuntimeCommandParser.parse(defaultCommand0, map, args) match {
+          case (commandName, command, commandArgs) =>
+            command.main(commandProgName(commandName), commandArgs.toArray)
+        }
+    }
+  }
+}

--- a/cats/shared/src/test/scala/caseapp/catseffect/CatsTests.scala
+++ b/cats/shared/src/test/scala/caseapp/catseffect/CatsTests.scala
@@ -16,6 +16,11 @@ sealed trait RecordedApp {
   def run(args: List[String]): IO[ExitCode]
 }
 
+sealed trait RecordedCommand {
+  val stdoutBuff: Ref[IO, List[String]] = Ref.unsafe(List.empty)
+  val stderrBuff: Ref[IO, List[String]] = Ref.unsafe(List.empty)
+}
+
 private class RecordedIOCaseApp[T](implicit parser0: Parser[T], messages: Help[T])
     extends IOCaseApp[T]()(parser0, messages) with RecordedApp {
 
@@ -78,6 +83,66 @@ object CatsTests extends TestSuite {
       }
       test("run") {
         testCaseStdout(List("--value", "foo", "--num-foo", "42"), "run: FewArgs(foo,42)")
+      }
+    }
+
+    test("IOCommandsEntryPoint") {
+      def mkEntryPoint() = {
+        val firstCmd = new IOCommand[Definitions.First] with RecordedCommand {
+          override def names: List[List[String]] = List(List("first"))
+          override def println(x: String): IO[Unit] = stdoutBuff.update(x :: _)
+          override def run(options: Definitions.First, remainingArgs: RemainingArgs): IO[ExitCode] =
+            stdoutBuff.update(s"first: $options" :: _).as(ExitCode.Success)
+          override def error(message: Error): IO[ExitCode] =
+            stderrBuff.update(message.message :: _).as(ExitCode.Error)
+        }
+        val secondCmd = new IOCommand[Definitions.Second] with RecordedCommand {
+          override def names: List[List[String]] = List(List("second"))
+          override def println(x: String): IO[Unit] = stdoutBuff.update(x :: _)
+          override def run(options: Definitions.Second, remainingArgs: RemainingArgs): IO[ExitCode] =
+            stdoutBuff.update(s"second: $options" :: _).as(ExitCode.Success)
+          override def error(message: Error): IO[ExitCode] =
+            stderrBuff.update(message.message :: _).as(ExitCode.Error)
+        }
+        new IOCommandsEntryPoint {
+          def progName = "test-app"
+          def commands = Seq(firstCmd, secondCmd)
+        }
+      }
+
+      test("dispatch to first command") {
+        val app = mkEntryPoint()
+        val firstCmd = app.commands.head.asInstanceOf[RecordedCommand]
+        app.run(List("first", "--foo", "hello", "--bar", "42"))
+          .flatMap { code =>
+            firstCmd.stdoutBuff.get.map { stdout =>
+              assert(code == ExitCode.Success)
+              assert(stdout == List("first: First(hello,42)"))
+            }
+          }
+          .unsafeToFuture()
+      }
+
+      test("dispatch to second command") {
+        val app = mkEntryPoint()
+        val secondCmd = app.commands(1).asInstanceOf[RecordedCommand]
+        app.run(List("second", "--fooh", "world", "--baz", "7"))
+          .flatMap { code =>
+            secondCmd.stdoutBuff.get.map { stdout =>
+              assert(code == ExitCode.Success)
+              assert(stdout == List("second: Second(world,7)"))
+            }
+          }
+          .unsafeToFuture()
+      }
+
+      test("no subcommand prints usage") {
+        val app = mkEntryPoint()
+        app.run(List())
+          .map { code =>
+            assert(code == ExitCode.Success)
+          }
+          .unsafeToFuture()
       }
     }
 

--- a/cats/shared/src/test/scala/caseapp/catseffect/CatsTests.scala
+++ b/cats/shared/src/test/scala/caseapp/catseffect/CatsTests.scala
@@ -89,7 +89,7 @@ object CatsTests extends TestSuite {
     test("IOCommandsEntryPoint") {
       def mkEntryPoint() = {
         val firstCmd = new IOCommand[Definitions.First] with RecordedCommand {
-          override def names: List[List[String]] = List(List("first"))
+          override def names: List[List[String]]    = List(List("first"))
           override def println(x: String): IO[Unit] = stdoutBuff.update(x :: _)
           override def run(options: Definitions.First, remainingArgs: RemainingArgs): IO[ExitCode] =
             stdoutBuff.update(s"first: $options" :: _).as(ExitCode.Success)
@@ -97,9 +97,12 @@ object CatsTests extends TestSuite {
             stderrBuff.update(message.message :: _).as(ExitCode.Error)
         }
         val secondCmd = new IOCommand[Definitions.Second] with RecordedCommand {
-          override def names: List[List[String]] = List(List("second"))
+          override def names: List[List[String]]    = List(List("second"))
           override def println(x: String): IO[Unit] = stdoutBuff.update(x :: _)
-          override def run(options: Definitions.Second, remainingArgs: RemainingArgs): IO[ExitCode] =
+          override def run(
+            options: Definitions.Second,
+            remainingArgs: RemainingArgs
+          ): IO[ExitCode] =
             stdoutBuff.update(s"second: $options" :: _).as(ExitCode.Success)
           override def error(message: Error): IO[ExitCode] =
             stderrBuff.update(message.message :: _).as(ExitCode.Error)
@@ -111,7 +114,7 @@ object CatsTests extends TestSuite {
       }
 
       test("dispatch to first command") {
-        val app = mkEntryPoint()
+        val app      = mkEntryPoint()
         val firstCmd = app.commands.head.asInstanceOf[RecordedCommand]
         app.run(List("first", "--foo", "hello", "--bar", "42"))
           .flatMap { code =>
@@ -124,7 +127,7 @@ object CatsTests extends TestSuite {
       }
 
       test("dispatch to second command") {
-        val app = mkEntryPoint()
+        val app       = mkEntryPoint()
         val secondCmd = app.commands(1).asInstanceOf[RecordedCommand]
         app.run(List("second", "--fooh", "world", "--baz", "7"))
           .flatMap { code =>

--- a/docs/pages/misc.md
+++ b/docs/pages/misc.md
@@ -17,7 +17,9 @@ println("```")
 ```
 (for other build tools, see [setup](setup.md) and change `case-app` to `case-app-cats`)
 
-Then use it like
+### Single command
+
+Use `IOCaseApp` for a single-command application:
 ```scala mdoc:silent
 import caseapp.catseffect._
 import cats.data.NonEmptyList
@@ -36,3 +38,52 @@ object IOCaseExample extends IOCaseApp[ExampleOptions] {
   }
 }
 ```
+
+### Multiple subcommands
+
+Use `IOCommand` and `IOCommandsEntryPoint` for applications with
+multiple subcommands — the cats-effect equivalents of `Command` and
+`CommandsEntryPoint`:
+
+```scala mdoc:reset-object:silent
+import caseapp._
+import caseapp.catseffect._
+import cats.effect._
+
+case class GrindOptions(
+  @HelpMessage("Type of beans")
+  beans: String = "arabica",
+  @HelpMessage("Grind size")
+  size: String = "medium"
+)
+
+object Grind extends IOCommand[GrindOptions] {
+  override def names = List(List("grind"))
+  def run(options: GrindOptions, args: RemainingArgs): IO[ExitCode] =
+    IO.println(s"Grinding ${options.beans} (${options.size})").as(ExitCode.Success)
+}
+
+case class BrewOptions(
+  @HelpMessage("Brewing method")
+  method: String = "pourover",
+  @HelpMessage("Water temperature in Celsius")
+  temp: Int = 96
+)
+
+object Brew extends IOCommand[BrewOptions] {
+  override def names = List(List("brew"))
+  def run(options: BrewOptions, args: RemainingArgs): IO[ExitCode] =
+    IO.println(s"Brewing with ${options.method} at ${options.temp}°C").as(ExitCode.Success)
+}
+
+object CoffeeApp extends IOCommandsEntryPoint {
+  def progName = "coffee"
+  def commands = Seq(Grind, Brew)
+}
+```
+
+`IOCommand` supports the same features as `Command`: custom `names`,
+`group`, `hidden`, and tab completion via `completer`.
+
+`IOCommandsEntryPoint` supports `defaultCommand` for a fallback
+when no subcommand is specified, just like `CommandsEntryPoint`.


### PR DESCRIPTION
## Summary

- Add `IOCommand[T]` — the cats-effect equivalent of `Command[T]`, with `def run(...): IO[ExitCode]`
- Add `IOCommandsEntryPoint` — the cats-effect equivalent of `CommandsEntryPoint`, extending `IOApp` with subcommand dispatch
- Add tests covering subcommand dispatch and no-subcommand usage output
- Document the new classes in the cats-effect section of the docs

## Motivation

`IOCaseApp` only supports single-command apps. For multi-subcommand CLI apps using cats-effect, users had to either use the non-IO `CommandsEntryPoint` (losing IO in `run`) or extend `IOApp` directly and manually dispatch via `RuntimeCommandParser.parse` with a hand-built map.

## Usage

```scala
object Grind extends IOCommand[GrindOptions] {
  override def names = List(List("grind"))
  def run(options: GrindOptions, args: RemainingArgs): IO[ExitCode] = ???
}

object CoffeeApp extends IOCommandsEntryPoint {
  def progName = "coffee"
  def commands = Seq(Grind, Brew)
}
```

## Test plan

- [x] Compiles on Scala 2.12, 2.13, 3.3
- [x] Tests pass on all three versions
- [x] Docs compile with mdoc
- [x] Sources formatted with scalafmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)